### PR TITLE
Marie LRU v0.7.8 (testing) patch for Linux 6.16, 6.18, 7.0, 7.1, 7.2

### DIFF
--- a/patches/testing/0001-linux6.16.12-lru_marie-0.7.8.patch
+++ b/patches/testing/0001-linux6.16.12-lru_marie-0.7.8.patch
@@ -1,7 +1,7 @@
 From cbe73c5e20d6d616592c130f9e4820dbd1708088 Mon Sep 17 00:00:00 2001
 From: Masahito S <firelzrd@gmail.com>
 Date: Thu, 16 Jul 2026 16:27:15 +0900
-Subject: [PATCH] linux6.16.12-lru_marie-0.7.7
+Subject: [PATCH] linux6.16.12-lru_marie-0.7.8
 
 Port Marie LRU v0.7.7 to Linux 6.16.y. Based on the 6.18 patch (the
 superset core: concede_pressure_mode + thrash_wd_mode knobs) with the
@@ -76,7 +76,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  mm/lru_marie/simd_x86_avx2.S   |  152 ++
  mm/lru_marie/simd_x86_avx512.S |  199 +++
  mm/lru_marie/simd_x86_sse2.S   |  158 +++
- mm/lru_marie/state.c           | 3014 ++++++++++++++++++++++++++++++++++++++++
+ mm/lru_marie/state.c           | 3013 ++++++++++++++++++++++++++++++++++++++++
  mm/lru_marie/state.h           |  987 +++++++++++++
  mm/lru_marie/state_compat.h    |  101 ++
  mm/lru_marie/version.h         |   22 +
@@ -92,7 +92,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  mm/swap.c                      |  248 +++-
  mm/swap.h                      |    4 +
  mm/vmscan.c                    |  332 ++++-
- 42 files changed, 11387 insertions(+), 27 deletions(-)
+ 42 files changed, 11386 insertions(+), 27 deletions(-)
 
 diff --git a/include/linux/lru_marie.h b/include/linux/lru_marie.h
 new file mode 100644
@@ -269,7 +269,7 @@ index 0000000000..fc30269822
 + * to enter the buddy allocator. When marie_state[pfn] still carries
 + * TRACKED -- which happens whenever the reclaim isolate path
 + * (marie_evict_counters_only) decremented counters but intentionally
-+ * preserved the state byte so install_local's TRACKED early-out kept
++ * preserved the state byte so marie_folio_install's TRACKED early-out kept
 + * blocking concurrent installs during shrink_folio_list -- this wipes
 + * the byte, the global (type, gen, tier) bitmap bit, and the
 + * gen_occupied slot in one lock-free pass.
@@ -1686,7 +1686,7 @@ index 0000000000..e2feeee275
 + *     no per-(lru, zone) shadow counter to bounce
 + *   - per-pgdat walker driven from kswapd, with rmap-fed bloom
 + *     feedback so PMD scans concentrate on hot regions
-+ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 4)
++ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 8)
 + *     encoded in the per-PFN byte, advanced by global install cadence
 + *     (marie_folio_install counts installs onto the head gen and
 + *     advances at marie_gen_growth_live[type])
@@ -1892,14 +1892,14 @@ index 0000000000..e2feeee275
 + *   - lru_marie_add_folio always lands on the current head gen
 + *     (atomic_read(&marie_head_gen[type])).
 + *   - marie_state_isolate_scan_l2lock always pulls from the oldest
-+ *     occupied gen (marie_find_oldest_occupied).
++ *     occupied gen (marie_find_oldest_occupied_mlv).
 + *   - shrink_folio_list classifies each isolated folio:
 + *       FOLIOREF_RECLAIM  → freed (this folio truly was cold)
 + *       FOLIOREF_KEEP     → returned in folio_list, putback re-routes
 + *       FOLIOREF_ACTIVATE → ditto, with PG_active set
-+ *     putback re-installs the survivor at (oldest+1)&3 with
++ *     putback re-installs the survivor at (oldest+1)&7 with
 + *     target_tier = max(prev_tier, w_tier) via
-+ *     marie_install_at_gen.
++ *     marie_state_publish_at_gen.
 + *   - head_gen advances per type via marie_try_advance_head_mlv (the
 + *     _mlv suffix is historical -- the clock is a single global one per
 + *     type), fired by global install cadence alone (marie_folio_install
@@ -5418,7 +5418,7 @@ new file mode 100644
 index 0000000000..4acf8318d6
 --- /dev/null
 +++ b/mm/lru_marie/state.c
-@@ -0,0 +1,3014 @@
+@@ -0,0 +1,3013 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Marie per-PFN state array — allocation, init, and global counters.
@@ -6258,7 +6258,7 @@ index 0000000000..4acf8318d6
 + * between marie_evict_counters_only (counters -1, TRACKED preserved) and
 + * the next allocation at the same PFN: the moment the page is destined
 + * for buddy, we wipe Marie's per-PFN bookkeeping so a subsequent
-+ * install_local starts from a clean state byte.
++ * marie_folio_install starts from a clean state byte.
 + *
 + * Counters are NOT touched here -- they were either already balanced
 + * by marie_evict_locked (the normal Marie del path) or pre-decremented
@@ -6481,9 +6481,9 @@ index 0000000000..4acf8318d6
 + * encodes (target_gen, target_tier).
 + *
 + * Called from:
-+ *   marie_state_inc_tier saturate path (target_gen=head, target_tier=0)
-+ *   shrink_lruvec residue putback (target_gen=(head+2)&3,
-+ *                                  target_tier=max(prev, w_tier))
++ *   marie_folio_demote / lru_marie_lazyfree (MADV_COLD / MADV_FREE),
++ *   both as (target_gen=oldest, target_tier=0). The tier-saturate
++ *   roll is open-coded inline in __marie_state_inc_tier instead.
 + */
 +void marie_state_move_to_gen(unsigned long pfn,
 +			     u8 target_gen, u8 target_tier)
@@ -6814,7 +6814,7 @@ index 0000000000..4acf8318d6
 +			    unsigned long nr_reclaimed,
 +			    u8 swappiness)
 +{
-+	s64 cur, delta;
++	s64 delta;
 +
 +	/*
 +	 * Special values bypass the controller. The pick path does not
@@ -6840,8 +6840,7 @@ index 0000000000..4acf8318d6
 +	else
 +		delta = +(s64)nr_reclaimed * (s64)swappiness;
 +
-+	cur = atomic64_read(&marie_swap_bias);
-+	atomic64_set(&marie_swap_bias, cur + delta);
++	atomic64_add(delta, &marie_swap_bias);
 +}
 +
 +/*
@@ -7016,7 +7015,7 @@ index 0000000000..4acf8318d6
 + * reclaim-driven trigger, fired ONLY on true exhaustion (the retired
 + * unconditional "occupied < 2 at entry" form thrashed the ring). Without
 + * demand-pull a workload that stops installing a type strands its
-+ * head-gen pages, since marie_find_oldest_occupied skips head (the
++ * head-gen pages, since marie_find_oldest_occupied_mlv skips head (the
 + * install destination).
 + *
 + * Per (type, tier) the scan walks the per-(gen, type) bitmap, claims
@@ -7024,7 +7023,7 @@ index 0000000000..4acf8318d6
 + * marie_evict_counters_only: counters decremented and the scan-bitmap
 + * slot + gen_occupied retired at isolate (so other CPUs stop re-finding
 + * the in-flight folio), but the per-PFN TRACKED byte is KEPT so
-+ * install_local's early-out blocks a concurrent install from re-setting
++ * marie_folio_install's early-out blocks a concurrent install from re-setting
 + * PG_lru while shrink_folio_list reclaims it.
 + *
 + * Teardown of the TRACKED byte is deferred: a reclaimed folio is wiped
@@ -7466,7 +7465,7 @@ index 0000000000..4acf8318d6
 +					 * counters AND retires the scan-bitmap
 +					 * slot (so other CPUs stop re-finding
 +					 * this in-flight folio), but KEEPS the
-+					 * TRACKED byte so install_local's early-
++					 * TRACKED byte so marie_folio_install's early-
 +					 * out blocks any concurrent install from
 +					 * re-setting PG_lru while shrink_folio_-
 +					 * list reclaims it. The TRACKED byte is
@@ -8134,7 +8133,7 @@ index 0000000000..4acf8318d6
 + *   1. folio_try_get()        - reference held, folio cannot be freed.
 + *   2. folio_test_clear_lru() - PG_lru cleared atomically, gating
 + *                                external del paths.
-+ *   3. install_local TRACKED early-out (above)
++ *   3. marie_folio_install TRACKED early-out (above)
 + *
 + * memcg_bitmap is cleared here because the buddy free hook
 + * (marie_state_drop_pfn_at_free) runs without a folio reference and cannot
@@ -8791,7 +8790,7 @@ index 0000000000..585bea9c8e
 +/*
 + * clean_min_ratio: minimum file-pagecache reserve as percent of
 + * node_present_pages. Sysfs-tunable in core.c, read by reclaim.
-+ * Default 15 (le9uo recommendation for desktop).
++ * Default 10.
 + */
 +extern unsigned int marie_clean_min_ratio;
 +
@@ -8941,11 +8940,11 @@ index 0000000000..585bea9c8e
 + * counter updates on both source and destination (gen, type) planes.
 + *
 + * Single point of policy for any operation that needs to move a folio
-+ * between gens. Two callers in design.h:
-+ *   - walker tier saturate (section 7):
-+ *       marie_state_move_to_gen(pfn, head, 0)
-+ *   - shrink_folio_list residue putback (section 13):
-+ *       marie_state_move_to_gen(pfn, (head + 2) & 3, max(prev, w))
++ * between gens. Callers (all in state.c):
++ *   - MADV_COLD demote (marie_folio_demote):
++ *       marie_state_move_to_gen(pfn, oldest, 0)
++ *   - MADV_FREE (lru_marie_lazyfree): same (pfn, oldest, 0) form.
++ *     (The reclaim putback now uses marie_state_publish_at_gen.)
 + *
 + * The state-byte cmpxchg defeats races against del / another
 + * concurrent move. The bitmap / counter shuffle uses "new first, then
@@ -8963,9 +8962,9 @@ index 0000000000..585bea9c8e
 + * marie_state_drop_pfn - wipe every per-PFN tracking artifact
 + * (state byte, (type, gen, tier) L1 bit, occupancy counter, global
 + * L2 range counter with bulk L2 clear on 0) for @folio. Shared by the
-+ * normal evict path (marie_evict_locked) and the enable=0 drain path
-+ * (marie_drain_one_lruvec) so disable->enable cycles never leave
-+ * ghost per-PFN state behind. No-op when the byte is not TRACKED.
++ * normal evict path (marie_evict_locked) -- the runtime enable=0
++ * drain that used to share it was removed together with the boot-only
++ * static key. No-op when the byte is not TRACKED.
 + */
 +void marie_state_drop_pfn(struct folio *folio);
 +
@@ -9331,14 +9330,14 @@ index 0000000000..585bea9c8e
 + * ---------------------------------------------------------------------
 + *
 + * No promote-queue or per-CPU staging drain remains: every install /
-+ * evict / tier bump is synchronous (install_local / install_locked
-+ * publish per-PFN state inline, evict_locked wipes it inline,
-+ * marie_state_inc_tier handles saturation via marie_state_move_to_gen
-+ * directly).
++ * evict / tier bump is synchronous (marie_folio_install publishes
++ * per-PFN state inline, marie_evict_locked wipes it inline,
++ * marie_state_inc_tier handles saturation via an inline gen roll in
++ * __marie_state_inc_tier).
 + *
-+ * The remaining drain entry, marie_drain_one_lruvec (in core.c), is
-+ * only the enable/disable transition: it walks the per-(type, gen,
-+ * tier) bitmap and hands every TRACKED folio back to the legacy LRU.
++ * No enable/disable drain entry remains either: Marie is selected
++ * once at boot via the lru_marie= static key, before any folio is
++ * tracked, so there is nothing to hand back to the legacy LRU.
 + */
 +
 +/*
@@ -9558,7 +9557,7 @@ index 0000000000..8edb82807a
 +#define MARIE_PROGNAME	"Marie LRU"
 +#define MARIE_AUTHOR	"Masahito Suzuki"
 +
-+#define MARIE_VERSION	"0.7.7"
++#define MARIE_VERSION	"0.7.8"
 +
 +#endif /* _MM_LRU_MARIE_VERSION_H */
 diff --git a/mm/lru_marie/walker.c b/mm/lru_marie/walker.c
@@ -11064,7 +11063,7 @@ index 2ef3c07266..aebd103755 100644
 +	/*
 +	 * Wipe Marie's per-PFN state at the buddy handoff. Marie's reclaim
 +	 * isolate path intentionally leaves marie_state[pfn]'s TRACKED bit
-+	 * set across shrink_folio_list (so install_local's TRACKED early-
++	 * set across shrink_folio_list (so marie_folio_install's TRACKED early-
 +	 * out keeps blocking concurrent installs on the in-flight folio);
 +	 * this hook is the canonical point at which that stale bit must
 +	 * disappear so the next allocation at this PFN starts clean. No-op

--- a/patches/testing/0001-linux6.18.22-lru_marie-0.7.8.patch
+++ b/patches/testing/0001-linux6.18.22-lru_marie-0.7.8.patch
@@ -1,13 +1,13 @@
-From 7c2f3a239e0c6e830c8092d1a23e7d70f30accf7 Mon Sep 17 00:00:00 2001
+From 831da586774ef91479f6b11e2629e0ff144910ed Mon Sep 17 00:00:00 2001
 From: Masahito S <firelzrd@gmail.com>
 Date: Mon, 13 Jul 2026 01:28:36 +0900
-Subject: [PATCH] linux7.2-rc1-lru_marie-0.7.7
+Subject: [PATCH] linux6.18.22-lru_marie-0.7.8
 
 ---
  include/linux/lru_marie.h      |  493 ++++++
  include/linux/memcontrol.h     |   26 +-
  include/linux/mm_inline.h      |  103 +-
- include/linux/mmzone.h         |   15 +
+ include/linux/mmzone.h         |   16 +
  include/linux/swap.h           |   18 +
  mm/Kconfig                     |   54 +
  mm/Makefile                    |    1 +
@@ -30,23 +30,23 @@ Subject: [PATCH] linux7.2-rc1-lru_marie-0.7.7
  mm/lru_marie/simd_x86_avx2.S   |  152 ++
  mm/lru_marie/simd_x86_avx512.S |  199 +++
  mm/lru_marie/simd_x86_sse2.S   |  158 ++
- mm/lru_marie/state.c           | 3014 ++++++++++++++++++++++++++++++++
+ mm/lru_marie/state.c           | 3013 ++++++++++++++++++++++++++++++++
  mm/lru_marie/state.h           |  987 +++++++++++
  mm/lru_marie/state_compat.h    |   94 +
  mm/lru_marie/version.h         |   22 +
  mm/lru_marie/walker.c          |  969 ++++++++++
  mm/lru_marie/walker_compat.h   |   82 +
  mm/memcontrol-v1.c             |   11 +
- mm/memcontrol.c                |   21 +
+ mm/memcontrol.c                |   13 +
  mm/mm_init.c                   |    3 +
- mm/oom_kill.c                  |  305 ++++
+ mm/oom_kill.c                  |  308 ++++
  mm/page_alloc.c                |  120 +-
  mm/page_io.c                   |  187 ++
  mm/rmap.c                      |    6 +
- mm/swap.c                      |  258 ++-
+ mm/swap.c                      |  248 ++-
  mm/swap.h                      |    4 +
- mm/vmscan.c                    |  336 +++-
- 42 files changed, 11384 insertions(+), 28 deletions(-)
+ mm/vmscan.c                    |  332 +++-
+ 42 files changed, 11366 insertions(+), 27 deletions(-)
  create mode 100644 include/linux/lru_marie.h
  create mode 100644 mm/lru_marie/Makefile
  create mode 100644 mm/lru_marie/account.h
@@ -246,7 +246,7 @@ index 0000000000..fc30269822
 + * to enter the buddy allocator. When marie_state[pfn] still carries
 + * TRACKED -- which happens whenever the reclaim isolate path
 + * (marie_evict_counters_only) decremented counters but intentionally
-+ * preserved the state byte so install_local's TRACKED early-out kept
++ * preserved the state byte so marie_folio_install's TRACKED early-out kept
 + * blocking concurrent installs during shrink_folio_list -- this wipes
 + * the byte, the global (type, gen, tier) bitmap bit, and the
 + * gen_occupied slot in one lock-free pass.
@@ -571,12 +571,12 @@ index 0000000000..fc30269822
 +
 +#endif /* _LINUX_LRU_MARIE_H */
 diff --git a/include/linux/memcontrol.h b/include/linux/memcontrol.h
-index e1f46a0016..dedb751ed4 100644
+index 1335911999..8cf24a1399 100644
 --- a/include/linux/memcontrol.h
 +++ b/include/linux/memcontrol.h
-@@ -877,14 +877,38 @@ static inline bool mem_cgroup_online(struct mem_cgroup *memcg)
+@@ -898,14 +898,38 @@ static inline bool mem_cgroup_online(struct mem_cgroup *memcg)
  void mem_cgroup_update_lru_size(struct lruvec *lruvec, enum lru_list lru,
- 		int zid, long nr_pages);
+ 		int zid, int nr_pages);
  
 +#ifdef CONFIG_LRU_MARIE
 +/*
@@ -615,7 +615,7 @@ index e1f46a0016..dedb751ed4 100644
  
  void __mem_cgroup_handle_over_high(gfp_t gfp_mask);
 diff --git a/include/linux/mm_inline.h b/include/linux/mm_inline.h
-index a8430a7ae0..da6659f066 100644
+index f6a2b2d200..3bc9367354 100644
 --- a/include/linux/mm_inline.h
 +++ b/include/linux/mm_inline.h
 @@ -5,6 +5,7 @@
@@ -626,7 +626,7 @@ index a8430a7ae0..da6659f066 100644
  #include <linux/swap.h>
  #include <linux/string.h>
  #include <linux/userfaultfd_k.h>
-@@ -36,7 +37,22 @@ static __always_inline void __update_lru_size(struct lruvec *lruvec,
+@@ -41,7 +42,22 @@ static __always_inline void __update_lru_size(struct lruvec *lruvec,
  {
  	struct pglist_data *pgdat = lruvec_pgdat(lruvec);
  
@@ -648,10 +648,10 @@ index a8430a7ae0..da6659f066 100644
 +#endif
  	WARN_ON_ONCE(nr_pages != (int)nr_pages);
  
- 	mod_lruvec_state(lruvec, NR_LRU_BASE + lru, nr_pages);
-@@ -104,14 +120,14 @@ static inline bool lru_gen_switching(void)
- 	return static_branch_unlikely(&lru_switch);
- }
+ 	__mod_lruvec_state(lruvec, NR_LRU_BASE + lru, nr_pages);
+@@ -103,14 +119,14 @@ static __always_inline enum lru_list folio_lru_list(const struct folio *folio)
+ #ifdef CONFIG_LRU_GEN
+ 
  #ifdef CONFIG_LRU_GEN_ENABLED
 -static inline bool lru_gen_enabled(void)
 +static inline bool lru_gen_core_enabled(void)
@@ -666,7 +666,7 @@ index a8430a7ae0..da6659f066 100644
  {
  	DECLARE_STATIC_KEY_FALSE(lru_gen_caps[NR_LRU_GEN_CAPS]);
  
-@@ -119,11 +135,57 @@ static inline bool lru_gen_enabled(void)
+@@ -118,11 +134,57 @@ static inline bool lru_gen_enabled(void)
  }
  #endif
  
@@ -724,7 +724,7 @@ index a8430a7ae0..da6659f066 100644
  static inline int lru_gen_from_seq(unsigned long seq)
  {
  	return seq % MAX_NR_GENS;
-@@ -312,6 +374,11 @@ static inline void folio_migrate_refs(struct folio *new, const struct folio *old
+@@ -311,11 +373,19 @@ static inline void folio_migrate_refs(struct folio *new, const struct folio *old
  }
  #else /* !CONFIG_LRU_GEN */
  
@@ -736,8 +736,6 @@ index a8430a7ae0..da6659f066 100644
  static inline bool lru_gen_enabled(void)
  {
  	return false;
-@@ -322,6 +389,9 @@ static inline bool lru_gen_switching(void)
- 	return false;
  }
  
 +static inline void lru_gen_fill_lruvec(struct lruvec *lruvec) { }
@@ -746,9 +744,9 @@ index a8430a7ae0..da6659f066 100644
  static inline bool lru_gen_in_fault(void)
  {
  	return false;
-@@ -350,8 +420,23 @@ void lruvec_add_folio(struct lruvec *lruvec, struct folio *folio)
- 
- 	VM_WARN_ON_ONCE_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
+@@ -342,8 +412,23 @@ void lruvec_add_folio(struct lruvec *lruvec, struct folio *folio)
+ {
+ 	enum lru_list lru = folio_lru_list(folio);
  
 +#ifdef CONFIG_LRU_MARIE
 +	if (lru_marie_add_folio(lruvec, folio, false))
@@ -770,9 +768,9 @@ index a8430a7ae0..da6659f066 100644
  
  	update_lru_size(lruvec, lru, folio_zonenum(folio),
  			folio_nr_pages(folio));
-@@ -366,8 +451,17 @@ void lruvec_add_folio_tail(struct lruvec *lruvec, struct folio *folio)
- 
- 	VM_WARN_ON_ONCE_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
+@@ -356,8 +441,17 @@ void lruvec_add_folio_tail(struct lruvec *lruvec, struct folio *folio)
+ {
+ 	enum lru_list lru = folio_lru_list(folio);
  
 +#ifdef CONFIG_LRU_MARIE
 +	if (lru_marie_add_folio(lruvec, folio, true))
@@ -788,9 +786,9 @@ index a8430a7ae0..da6659f066 100644
  
  	update_lru_size(lruvec, lru, folio_zonenum(folio),
  			folio_nr_pages(folio));
-@@ -382,6 +476,11 @@ void lruvec_del_folio(struct lruvec *lruvec, struct folio *folio)
- 
- 	VM_WARN_ON_ONCE_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
+@@ -370,6 +464,11 @@ void lruvec_del_folio(struct lruvec *lruvec, struct folio *folio)
+ {
+ 	enum lru_list lru = folio_lru_list(folio);
  
 +#ifdef CONFIG_LRU_MARIE
 +	if (lru_marie_del_folio(lruvec, folio, false))
@@ -801,18 +799,19 @@ index a8430a7ae0..da6659f066 100644
  		return;
  
 diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
-index ca27121871..9430caa4a0 100644
+index 7fb7331c57..521d39f68f 100644
 --- a/include/linux/mmzone.h
 +++ b/include/linux/mmzone.h
-@@ -24,6 +24,7 @@
+@@ -23,6 +23,8 @@
+ #include <linux/page-flags.h>
  #include <linux/local_lock.h>
  #include <linux/zswap.h>
- #include <linux/sizes.h>
++#include <linux/sizes.h>
 +#include <linux/kfifo.h>
  #include <asm/page.h>
  
  /* Free memory management - zoned buddy allocator.  */
-@@ -1522,6 +1523,20 @@ typedef struct pglist_data {
+@@ -1442,6 +1444,20 @@ typedef struct pglist_data {
  
  	atomic_t kswapd_failures;	/* Number of 'reclaimed == 0' runs */
  
@@ -834,10 +833,10 @@ index ca27121871..9430caa4a0 100644
  	int kcompactd_max_order;
  	enum zone_type kcompactd_highest_zoneidx;
 diff --git a/include/linux/swap.h b/include/linux/swap.h
-index 8f0f68e245..66eaf4f962 100644
+index e818fbade1..e7b8b27ed6 100644
 --- a/include/linux/swap.h
 +++ b/include/linux/swap.h
-@@ -421,6 +421,24 @@ extern atomic_long_t nr_swap_pages;
+@@ -450,6 +450,24 @@ extern atomic_long_t nr_swap_pages;
  extern long total_swap_pages;
  extern atomic_t nr_rotate_swap;
  
@@ -863,10 +862,10 @@ index 8f0f68e245..66eaf4f962 100644
  static inline bool vm_swap_full(void)
  {
 diff --git a/mm/Kconfig b/mm/Kconfig
-index 9e0ca48249..62381669b0 100644
+index 76001e9ba0..585bc58f9b 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
-@@ -1435,6 +1435,60 @@ config LRU_GEN_WALKS_MMU
+@@ -1329,6 +1329,60 @@ config LRU_GEN_WALKS_MMU
  	depends on LRU_GEN && ARCH_HAS_HW_PTE_YOUNG
  # }
  
@@ -928,7 +927,7 @@ index 9e0ca48249..62381669b0 100644
         def_bool n
  
 diff --git a/mm/Makefile b/mm/Makefile
-index eff9f9e7e0..b82d9b6ac3 100644
+index 21abb33535..f81f8c8be8 100644
 --- a/mm/Makefile
 +++ b/mm/Makefile
 @@ -76,6 +76,7 @@ ifdef CONFIG_MMU
@@ -938,9 +937,9 @@ index eff9f9e7e0..b82d9b6ac3 100644
 +obj-$(CONFIG_LRU_MARIE)	+= lru_marie/
  obj-$(CONFIG_ZSWAP)	+= zswap.o
  obj-$(CONFIG_HAS_DMA)	+= dmapool.o
- obj-$(CONFIG_HUGETLBFS)	+= hugetlb.o hugetlb_sysfs.o hugetlb_sysctl.o
+ obj-$(CONFIG_HUGETLBFS)	+= hugetlb.o
 diff --git a/mm/compaction.c b/mm/compaction.c
-index b776f35ad0..35e49b17dc 100644
+index 1e8f8eca31..972e79c836 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -24,6 +24,7 @@
@@ -951,7 +950,7 @@ index b776f35ad0..35e49b17dc 100644
  #include "internal.h"
  
  #ifdef CONFIG_COMPACTION
-@@ -3097,6 +3098,23 @@ static void kcompactd_do_work(pg_data_t *pgdat)
+@@ -3075,6 +3076,23 @@ static void kcompactd_do_work(pg_data_t *pgdat)
  							cc.highest_zoneidx);
  	count_compact_event(KCOMPACTD_WAKE);
  
@@ -975,7 +974,7 @@ index b776f35ad0..35e49b17dc 100644
  	for (zoneid = 0; zoneid <= cc.highest_zoneidx; zoneid++) {
  		int status;
  
-@@ -3233,7 +3251,19 @@ static int kcompactd(void *p)
+@@ -3211,7 +3229,19 @@ static int kcompactd(void *p)
  			unsigned int prev_score, score;
  
  			prev_score = fragmentation_score_node(pgdat);
@@ -997,7 +996,7 @@ index b776f35ad0..35e49b17dc 100644
  			/*
  			 * Defer proactive compaction if the fragmentation
 diff --git a/mm/huge_memory.c b/mm/huge_memory.c
-index 2bccb0a53a..31ffbe3610 100644
+index 8218e9d188..6b11aa0d70 100644
 --- a/mm/huge_memory.c
 +++ b/mm/huge_memory.c
 @@ -6,6 +6,7 @@
@@ -1008,7 +1007,7 @@ index 2bccb0a53a..31ffbe3610 100644
  #include <linux/sched.h>
  #include <linux/sched/mm.h>
  #include <linux/sched/numa_balancing.h>
-@@ -3500,14 +3501,48 @@ static void lru_add_split_folio(struct folio *folio, struct folio *new_folio,
+@@ -3239,14 +3240,48 @@ static void lru_add_split_folio(struct folio *folio, struct folio *new_folio,
  		/* page reclaim is reclaiming a huge page */
  		VM_WARN_ON(folio_test_lru(folio));
  		folio_get(new_folio);
@@ -1060,10 +1059,10 @@ index 2bccb0a53a..31ffbe3610 100644
  	}
  }
 diff --git a/mm/internal.h b/mm/internal.h
-index 181e79f1d6..9b88fa9da3 100644
+index c80c6f566c..37721deb60 100644
 --- a/mm/internal.h
 +++ b/mm/internal.h
-@@ -616,12 +616,55 @@ extern unsigned long highest_memmap_pfn;
+@@ -532,12 +532,55 @@ extern unsigned long highest_memmap_pfn;
   */
  #define MAX_RECLAIM_RETRIES 16
  
@@ -1119,7 +1118,7 @@ index 181e79f1d6..9b88fa9da3 100644
  int user_proactive_reclaim(char *buf,
  			   struct mem_cgroup *memcg, pg_data_t *pgdat);
  
-@@ -684,6 +727,30 @@ struct alloc_context {
+@@ -595,6 +638,30 @@ struct alloc_context {
  	 */
  	enum zone_type highest_zoneidx;
  	bool spread_dirty_pages;
@@ -1664,7 +1663,7 @@ index 0000000000..e2feeee275
 + *     no per-(lru, zone) shadow counter to bounce
 + *   - per-pgdat walker driven from kswapd, with rmap-fed bloom
 + *     feedback so PMD scans concentrate on hot regions
-+ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 4)
++ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 8)
 + *     encoded in the per-PFN byte, advanced by global install cadence
 + *     (marie_folio_install counts installs onto the head gen and
 + *     advances at marie_gen_growth_live[type])
@@ -1870,14 +1869,14 @@ index 0000000000..e2feeee275
 + *   - lru_marie_add_folio always lands on the current head gen
 + *     (atomic_read(&marie_head_gen[type])).
 + *   - marie_state_isolate_scan_l2lock always pulls from the oldest
-+ *     occupied gen (marie_find_oldest_occupied).
++ *     occupied gen (marie_find_oldest_occupied_mlv).
 + *   - shrink_folio_list classifies each isolated folio:
 + *       FOLIOREF_RECLAIM  → freed (this folio truly was cold)
 + *       FOLIOREF_KEEP     → returned in folio_list, putback re-routes
 + *       FOLIOREF_ACTIVATE → ditto, with PG_active set
-+ *     putback re-installs the survivor at (oldest+1)&3 with
++ *     putback re-installs the survivor at (oldest+1)&7 with
 + *     target_tier = max(prev_tier, w_tier) via
-+ *     marie_install_at_gen.
++ *     marie_state_publish_at_gen.
 + *   - head_gen advances per type via marie_try_advance_head_mlv (the
 + *     _mlv suffix is historical -- the clock is a single global one per
 + *     type), fired by global install cadence alone (marie_folio_install
@@ -5396,7 +5395,7 @@ new file mode 100644
 index 0000000000..4acf8318d6
 --- /dev/null
 +++ b/mm/lru_marie/state.c
-@@ -0,0 +1,3014 @@
+@@ -0,0 +1,3013 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Marie per-PFN state array — allocation, init, and global counters.
@@ -6236,7 +6235,7 @@ index 0000000000..4acf8318d6
 + * between marie_evict_counters_only (counters -1, TRACKED preserved) and
 + * the next allocation at the same PFN: the moment the page is destined
 + * for buddy, we wipe Marie's per-PFN bookkeeping so a subsequent
-+ * install_local starts from a clean state byte.
++ * marie_folio_install starts from a clean state byte.
 + *
 + * Counters are NOT touched here -- they were either already balanced
 + * by marie_evict_locked (the normal Marie del path) or pre-decremented
@@ -6459,9 +6458,9 @@ index 0000000000..4acf8318d6
 + * encodes (target_gen, target_tier).
 + *
 + * Called from:
-+ *   marie_state_inc_tier saturate path (target_gen=head, target_tier=0)
-+ *   shrink_lruvec residue putback (target_gen=(head+2)&3,
-+ *                                  target_tier=max(prev, w_tier))
++ *   marie_folio_demote / lru_marie_lazyfree (MADV_COLD / MADV_FREE),
++ *   both as (target_gen=oldest, target_tier=0). The tier-saturate
++ *   roll is open-coded inline in __marie_state_inc_tier instead.
 + */
 +void marie_state_move_to_gen(unsigned long pfn,
 +			     u8 target_gen, u8 target_tier)
@@ -6792,7 +6791,7 @@ index 0000000000..4acf8318d6
 +			    unsigned long nr_reclaimed,
 +			    u8 swappiness)
 +{
-+	s64 cur, delta;
++	s64 delta;
 +
 +	/*
 +	 * Special values bypass the controller. The pick path does not
@@ -6818,8 +6817,7 @@ index 0000000000..4acf8318d6
 +	else
 +		delta = +(s64)nr_reclaimed * (s64)swappiness;
 +
-+	cur = atomic64_read(&marie_swap_bias);
-+	atomic64_set(&marie_swap_bias, cur + delta);
++	atomic64_add(delta, &marie_swap_bias);
 +}
 +
 +/*
@@ -6994,7 +6992,7 @@ index 0000000000..4acf8318d6
 + * reclaim-driven trigger, fired ONLY on true exhaustion (the retired
 + * unconditional "occupied < 2 at entry" form thrashed the ring). Without
 + * demand-pull a workload that stops installing a type strands its
-+ * head-gen pages, since marie_find_oldest_occupied skips head (the
++ * head-gen pages, since marie_find_oldest_occupied_mlv skips head (the
 + * install destination).
 + *
 + * Per (type, tier) the scan walks the per-(gen, type) bitmap, claims
@@ -7002,7 +7000,7 @@ index 0000000000..4acf8318d6
 + * marie_evict_counters_only: counters decremented and the scan-bitmap
 + * slot + gen_occupied retired at isolate (so other CPUs stop re-finding
 + * the in-flight folio), but the per-PFN TRACKED byte is KEPT so
-+ * install_local's early-out blocks a concurrent install from re-setting
++ * marie_folio_install's early-out blocks a concurrent install from re-setting
 + * PG_lru while shrink_folio_list reclaims it.
 + *
 + * Teardown of the TRACKED byte is deferred: a reclaimed folio is wiped
@@ -7444,7 +7442,7 @@ index 0000000000..4acf8318d6
 +					 * counters AND retires the scan-bitmap
 +					 * slot (so other CPUs stop re-finding
 +					 * this in-flight folio), but KEEPS the
-+					 * TRACKED byte so install_local's early-
++					 * TRACKED byte so marie_folio_install's early-
 +					 * out blocks any concurrent install from
 +					 * re-setting PG_lru while shrink_folio_-
 +					 * list reclaims it. The TRACKED byte is
@@ -8112,7 +8110,7 @@ index 0000000000..4acf8318d6
 + *   1. folio_try_get()        - reference held, folio cannot be freed.
 + *   2. folio_test_clear_lru() - PG_lru cleared atomically, gating
 + *                                external del paths.
-+ *   3. install_local TRACKED early-out (above)
++ *   3. marie_folio_install TRACKED early-out (above)
 + *
 + * memcg_bitmap is cleared here because the buddy free hook
 + * (marie_state_drop_pfn_at_free) runs without a folio reference and cannot
@@ -8769,7 +8767,7 @@ index 0000000000..585bea9c8e
 +/*
 + * clean_min_ratio: minimum file-pagecache reserve as percent of
 + * node_present_pages. Sysfs-tunable in core.c, read by reclaim.
-+ * Default 15 (le9uo recommendation for desktop).
++ * Default 10.
 + */
 +extern unsigned int marie_clean_min_ratio;
 +
@@ -8919,11 +8917,11 @@ index 0000000000..585bea9c8e
 + * counter updates on both source and destination (gen, type) planes.
 + *
 + * Single point of policy for any operation that needs to move a folio
-+ * between gens. Two callers in design.h:
-+ *   - walker tier saturate (section 7):
-+ *       marie_state_move_to_gen(pfn, head, 0)
-+ *   - shrink_folio_list residue putback (section 13):
-+ *       marie_state_move_to_gen(pfn, (head + 2) & 3, max(prev, w))
++ * between gens. Callers (all in state.c):
++ *   - MADV_COLD demote (marie_folio_demote):
++ *       marie_state_move_to_gen(pfn, oldest, 0)
++ *   - MADV_FREE (lru_marie_lazyfree): same (pfn, oldest, 0) form.
++ *     (The reclaim putback now uses marie_state_publish_at_gen.)
 + *
 + * The state-byte cmpxchg defeats races against del / another
 + * concurrent move. The bitmap / counter shuffle uses "new first, then
@@ -8941,9 +8939,9 @@ index 0000000000..585bea9c8e
 + * marie_state_drop_pfn - wipe every per-PFN tracking artifact
 + * (state byte, (type, gen, tier) L1 bit, occupancy counter, global
 + * L2 range counter with bulk L2 clear on 0) for @folio. Shared by the
-+ * normal evict path (marie_evict_locked) and the enable=0 drain path
-+ * (marie_drain_one_lruvec) so disable->enable cycles never leave
-+ * ghost per-PFN state behind. No-op when the byte is not TRACKED.
++ * normal evict path (marie_evict_locked) -- the runtime enable=0
++ * drain that used to share it was removed together with the boot-only
++ * static key. No-op when the byte is not TRACKED.
 + */
 +void marie_state_drop_pfn(struct folio *folio);
 +
@@ -9309,14 +9307,14 @@ index 0000000000..585bea9c8e
 + * ---------------------------------------------------------------------
 + *
 + * No promote-queue or per-CPU staging drain remains: every install /
-+ * evict / tier bump is synchronous (install_local / install_locked
-+ * publish per-PFN state inline, evict_locked wipes it inline,
-+ * marie_state_inc_tier handles saturation via marie_state_move_to_gen
-+ * directly).
++ * evict / tier bump is synchronous (marie_folio_install publishes
++ * per-PFN state inline, marie_evict_locked wipes it inline,
++ * marie_state_inc_tier handles saturation via an inline gen roll in
++ * __marie_state_inc_tier).
 + *
-+ * The remaining drain entry, marie_drain_one_lruvec (in core.c), is
-+ * only the enable/disable transition: it walks the per-(type, gen,
-+ * tier) bitmap and hands every TRACKED folio back to the legacy LRU.
++ * No enable/disable drain entry remains either: Marie is selected
++ * once at boot via the lru_marie= static key, before any folio is
++ * tracked, so there is nothing to hand back to the legacy LRU.
 + */
 +
 +/*
@@ -9529,7 +9527,7 @@ index 0000000000..8edb82807a
 +#define MARIE_PROGNAME	"Marie LRU"
 +#define MARIE_AUTHOR	"Masahito Suzuki"
 +
-+#define MARIE_VERSION	"0.7.7"
++#define MARIE_VERSION	"0.7.8"
 +
 +#endif /* _MM_LRU_MARIE_VERSION_H */
 diff --git a/mm/lru_marie/walker.c b/mm/lru_marie/walker.c
@@ -10596,10 +10594,10 @@ index 0000000000..5942d25151
 +
 +#endif /* _MM_LRU_MARIE_WALKER_COMPAT_H */
 diff --git a/mm/memcontrol-v1.c b/mm/memcontrol-v1.c
-index 7650692115..16636e0d43 100644
+index 6eed14bff7..4683579be1 100644
 --- a/mm/memcontrol-v1.c
 +++ b/mm/memcontrol-v1.c
-@@ -10,6 +10,7 @@
+@@ -11,6 +11,7 @@
  #include <linux/sort.h>
  #include <linux/file.h>
  #include <linux/seq_buf.h>
@@ -10607,7 +10605,7 @@ index 7650692115..16636e0d43 100644
  
  #include "internal.h"
  #include "swap.h"
-@@ -2020,6 +2021,16 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
+@@ -1962,6 +1963,16 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
  	} else
  		WRITE_ONCE(vm_swappiness, val);
  
@@ -10625,7 +10623,7 @@ index 7650692115..16636e0d43 100644
  }
  
 diff --git a/mm/memcontrol.c b/mm/memcontrol.c
-index 6dc4888a90..b00c2ee52d 100644
+index 61cf6af26f..ec13c53cd4 100644
 --- a/mm/memcontrol.c
 +++ b/mm/memcontrol.c
 @@ -28,6 +28,7 @@
@@ -10636,7 +10634,7 @@ index 6dc4888a90..b00c2ee52d 100644
  #include <linux/cgroup.h>
  #include <linux/cpuset.h>
  #include <linux/sched/mm.h>
-@@ -5287,6 +5288,26 @@ static void uncharge_folio(struct folio *folio, struct uncharge_gather *ug)
+@@ -4873,6 +4874,18 @@ static void uncharge_folio(struct folio *folio, struct uncharge_gather *ug)
  			ug->nr_memory += nr_pages;
  		ug->pgpgout++;
  
@@ -10648,26 +10646,18 @@ index 6dc4888a90..b00c2ee52d 100644
 +		 * page-free hook that follows runs after memcg_data is zeroed
 +		 * and cannot resolve the lruvec. No-op for the common case (bit
 +		 * already retired by the normal evict path).
-+		 *
-+		 * 7.1: uncharge_folio is objcg-only (no memcg local). Resolve
-+		 * the owning memcg from the pinned objcg under RCU --
-+		 * obj_cgroup_memcg() requires it (objcg->memcg may be swapped to
-+		 * the parent at reparent), and the read section keeps the
-+		 * resolved memcg alive across the backstop's lruvec debit.
 +		 */
-+		rcu_read_lock();
-+		lru_marie_uncharge_backstop(folio, obj_cgroup_memcg(objcg));
-+		rcu_read_unlock();
++		lru_marie_uncharge_backstop(folio, memcg);
 +#endif
 +
  		WARN_ON_ONCE(folio_unqueue_deferred_split(folio));
+ 		folio->memcg_data = 0;
  	}
- 
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index 0f64909e8d..b8c8f26987 100644
+index 7712d887b6..7bc5c1d657 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
-@@ -1395,6 +1395,9 @@ static void __meminit pgdat_init_internals(struct pglist_data *pgdat)
+@@ -1412,6 +1412,9 @@ static void __meminit pgdat_init_internals(struct pglist_data *pgdat)
  	pgdat_init_kcompactd(pgdat);
  
  	init_waitqueue_head(&pgdat->kswapd_wait);
@@ -10678,7 +10668,7 @@ index 0f64909e8d..b8c8f26987 100644
  
  	for (i = 0; i < NR_VMSCAN_THROTTLE; i++)
 diff --git a/mm/oom_kill.c b/mm/oom_kill.c
-index 5f372f6e26..7020c0861f 100644
+index c145b0feec..c33bdac475 100644
 --- a/mm/oom_kill.c
 +++ b/mm/oom_kill.c
 @@ -45,6 +45,10 @@
@@ -10712,7 +10702,7 @@ index 5f372f6e26..7020c0861f 100644
  
  /*
   * Serializes oom killer invocations (out_of_memory()) from all contexts to
-@@ -720,6 +737,15 @@ static const struct ctl_table vm_oom_kill_table[] = {
+@@ -735,6 +752,15 @@ static const struct ctl_table vm_oom_kill_table[] = {
  		.mode		= 0644,
  		.proc_handler	= proc_dointvec,
  	},
@@ -10728,11 +10718,12 @@ index 5f372f6e26..7020c0861f 100644
  };
  #endif
  
-@@ -1255,3 +1281,282 @@ SYSCALL_DEFINE2(process_mrelease, int, pidfd, unsigned int, flags)
+@@ -1270,3 +1296,285 @@ SYSCALL_DEFINE2(process_mrelease, int, pidfd, unsigned int, flags)
  	return -ENOSYS;
  #endif /* CONFIG_MMU */
  }
 +
++#ifdef CONFIG_VM_EVENT_COUNTERS
 +/*
 + * Thrash-livelock watchdog.
 + *
@@ -10954,11 +10945,12 @@ index 5f372f6e26..7020c0861f 100644
 +		 * streaming page cache with gigabytes free is not mistaken for a
 +		 * livelock -- see thrash_wd_mem_pressured().
 +		 */
++		unsigned long ev[NR_VM_EVENT_ITEMS];
 +		unsigned long refaults, steals, dr, ds;
 +
-+		steals = global_node_page_state(PGSTEAL_KSWAPD) +
-+			 global_node_page_state(PGSTEAL_DIRECT) +
-+			 global_node_page_state(PGSTEAL_KHUGEPAGED);
++		all_vm_events(ev);
++		steals = ev[PGSTEAL_KSWAPD] + ev[PGSTEAL_DIRECT] +
++			 ev[PGSTEAL_KHUGEPAGED];
 +		refaults = global_node_page_state(WORKINGSET_REFAULT_ANON) +
 +			   global_node_page_state(WORKINGSET_REFAULT_FILE);
 +
@@ -11011,11 +11003,12 @@ index 5f372f6e26..7020c0861f 100644
 +	return 0;
 +}
 +late_initcall(thrash_wd_init);
++#endif /* CONFIG_VM_EVENT_COUNTERS */
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index ee902a468c..04c93a3b9a 100644
+index 6288c7e4b9..58678db525 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -16,6 +16,7 @@
+@@ -17,6 +17,7 @@
  
  #include <linux/stddef.h>
  #include <linux/mm.h>
@@ -11023,7 +11016,7 @@ index ee902a468c..04c93a3b9a 100644
  #include <linux/highmem.h>
  #include <linux/interrupt.h>
  #include <linux/jiffies.h>
-@@ -1326,6 +1327,28 @@ static __always_inline bool __free_pages_prepare(struct page *page,
+@@ -1353,6 +1354,28 @@ __always_inline bool __free_pages_prepare(struct page *page,
  	trace_mm_page_free(page, order);
  	kmsan_free_page(page, order);
  
@@ -11031,7 +11024,7 @@ index ee902a468c..04c93a3b9a 100644
 +	/*
 +	 * Wipe Marie's per-PFN state at the buddy handoff. Marie's reclaim
 +	 * isolate path intentionally leaves marie_state[pfn]'s TRACKED bit
-+	 * set across shrink_folio_list (so install_local's TRACKED early-
++	 * set across shrink_folio_list (so marie_folio_install's TRACKED early-
 +	 * out keeps blocking concurrent installs on the in-flight folio);
 +	 * this hook is the canonical point at which that stale bit must
 +	 * disappear so the next allocation at this PFN starts clean. No-op
@@ -11052,7 +11045,7 @@ index ee902a468c..04c93a3b9a 100644
  	if (memcg_kmem_online() && PageMemcgKmem(page))
  		__memcg_kmem_uncharge_page(page, order);
  
-@@ -4580,25 +4603,97 @@ bool gfp_pfmemalloc_allowed(gfp_t gfp_mask)
+@@ -4554,25 +4577,97 @@ bool gfp_pfmemalloc_allowed(gfp_t gfp_mask)
  static inline bool
  should_reclaim_retry(gfp_t gfp_mask, unsigned order,
  		     struct alloc_context *ac, int alloc_flags,
@@ -11153,7 +11146,7 @@ index ee902a468c..04c93a3b9a 100644
  
  	/*
  	 * Keep reclaiming pages while there is a chance this will lead
-@@ -4757,6 +4852,20 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4699,6 +4794,20 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  		WARN_ON_ONCE(current->flags & PF_MEMALLOC);
  	}
  
@@ -11174,7 +11167,7 @@ index ee902a468c..04c93a3b9a 100644
  restart:
  	compaction_retries = 0;
  	no_progress_loops = 0;
-@@ -4764,6 +4873,9 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4706,6 +4815,9 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  	compact_priority = DEF_COMPACT_PRIORITY;
  	cpuset_mems_cookie = read_mems_allowed_begin();
  	zonelist_iter_cookie = zonelist_iter_begin();
@@ -11183,9 +11176,9 @@ index ee902a468c..04c93a3b9a 100644
 +			    global_node_page_state(WORKINGSET_REFAULT_FILE);
  
  	/*
- 	 * For costly allocations, try direct compaction first, as it's likely
-@@ -4934,7 +5046,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
- 		goto restart;
+ 	 * The fast path uses conservative alloc_flags to succeed only until
+@@ -4885,7 +4997,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 		goto nopage;
  
  	if (should_reclaim_retry(gfp_mask, order, ac, alloc_flags,
 -				 did_some_progress > 0, &no_progress_loops))
@@ -11194,17 +11187,16 @@ index ee902a468c..04c93a3b9a 100644
  
  	/*
 diff --git a/mm/page_io.c b/mm/page_io.c
-index b23f494fcc..63ff90fa90 100644
+index 3c342db77c..6e337a99ec 100644
 --- a/mm/page_io.c
 +++ b/mm/page_io.c
-@@ -25,9 +25,20 @@
+@@ -25,8 +25,19 @@
  #include <linux/sched/task.h>
  #include <linux/delayacct.h>
  #include <linux/zswap.h>
 +#include <linux/kfifo.h>
 +#include <linux/lru_marie.h>
  #include "swap.h"
- #include "swap_table.h"
  
 +#ifdef CONFIG_LRU_MARIE
 +/*
@@ -11218,7 +11210,7 @@ index b23f494fcc..63ff90fa90 100644
  static void __end_swap_bio_write(struct bio *bio)
  {
  	struct folio *folio = bio_first_folio_all(bio);
-@@ -40,7 +51,21 @@ static void __end_swap_bio_write(struct bio *bio)
+@@ -39,7 +50,21 @@ static void __end_swap_bio_write(struct bio *bio)
  		 * very quickly.
  		 *
  		 * Also clear PG_reclaim to avoid folio_rotate_reclaimable()
@@ -11240,8 +11232,8 @@ index b23f494fcc..63ff90fa90 100644
  		folio_mark_dirty(folio);
  		pr_alert_ratelimited("Write-error on swap-device (%u:%u:%llu)\n",
  				     MAJOR(bio_dev(bio)), MINOR(bio_dev(bio)),
-@@ -244,6 +269,120 @@ static void swap_zeromap_folio_clear(struct folio *folio)
- 	swap_cluster_unlock(ci);
+@@ -233,6 +258,120 @@ static void swap_zeromap_folio_clear(struct folio *folio)
+ 	}
  }
  
 +/*
@@ -11361,7 +11353,7 @@ index b23f494fcc..63ff90fa90 100644
  /*
   * We may have stale swap cache pages in memory: notice
   * them here and get rid of the unnecessary final write.
-@@ -282,6 +421,14 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
+@@ -272,6 +411,14 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
  	 */
  	swap_zeromap_folio_clear(folio);
  
@@ -11376,7 +11368,7 @@ index b23f494fcc..63ff90fa90 100644
  	if (zswap_store(folio)) {
  		count_mthp_stat(folio_order(folio), MTHP_STAT_ZSWPOUT);
  		goto out_unlock;
-@@ -302,6 +449,46 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
+@@ -288,6 +435,46 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
  	return ret;
  }
  
@@ -11424,7 +11416,7 @@ index b23f494fcc..63ff90fa90 100644
  {
  #ifdef CONFIG_TRANSPARENT_HUGEPAGE
 diff --git a/mm/rmap.c b/mm/rmap.c
-index 1c77d5dc06..898b893c09 100644
+index 8f3c50bd11..818ee3881a 100644
 --- a/mm/rmap.c
 +++ b/mm/rmap.c
 @@ -75,6 +75,7 @@
@@ -11435,20 +11427,20 @@ index 1c77d5dc06..898b893c09 100644
  
  #include <asm/tlb.h>
  
-@@ -981,6 +982,11 @@ static bool folio_referenced_one(struct folio *folio,
- 		if (lru_gen_enabled() && !lru_gen_switching() && pvmw.pte) {
- 			if (lru_gen_look_around(&pvmw, nr))
+@@ -897,6 +898,11 @@ static bool folio_referenced_one(struct folio *folio,
+ 		if (lru_gen_enabled() && pvmw.pte) {
+ 			if (lru_gen_look_around(&pvmw))
  				referenced++;
 +#ifdef CONFIG_LRU_MARIE
 +		} else if (lru_marie_enabled() && pvmw.pte) {
-+			if (lru_marie_look_around(&pvmw, nr))
++			if (lru_marie_look_around(&pvmw, pvmw.nr_pages))
 +				referenced++;
 +#endif
  		} else if (pvmw.pte) {
- 			if (clear_flush_young_ptes_notify(vma, address, pvmw.pte, nr))
- 				referenced++;
+ 			if (ptep_clear_flush_young_notify(vma, address,
+ 						pvmw.pte))
 diff --git a/mm/swap.c b/mm/swap.c
-index 588f50d8f1..ec05a13949 100644
+index 2260dcd277..7838fe0484 100644
 --- a/mm/swap.c
 +++ b/mm/swap.c
 @@ -37,6 +37,7 @@
@@ -11503,7 +11495,7 @@ index 588f50d8f1..ec05a13949 100644
  }
  
  /*
-@@ -199,6 +228,27 @@ static void folio_batch_move_lru(struct folio_batch *fbatch, move_fn_t move_fn)
+@@ -171,6 +200,27 @@ static void folio_batch_move_lru(struct folio_batch *fbatch, move_fn_t move_fn)
  		folio_lruvec_relock_irqsave(folio, &lruvec, &flags);
  		move_fn(lruvec, folio);
  
@@ -11531,7 +11523,7 @@ index 588f50d8f1..ec05a13949 100644
  		folio_set_lru(folio);
  	}
  
-@@ -250,6 +300,44 @@ static void lru_move_tail(struct lruvec *lruvec, struct folio *folio)
+@@ -215,6 +265,44 @@ static void lru_move_tail(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_unevictable(folio))
  		return;
  
@@ -11576,7 +11568,7 @@ index 588f50d8f1..ec05a13949 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	lruvec_add_folio_tail(lruvec, folio);
-@@ -269,6 +357,14 @@ void folio_rotate_reclaimable(struct folio *folio)
+@@ -234,6 +322,14 @@ void folio_rotate_reclaimable(struct folio *folio)
  	    folio_test_unevictable(folio) || !folio_test_lru(folio))
  		return;
  
@@ -11591,7 +11583,7 @@ index 588f50d8f1..ec05a13949 100644
  	folio_batch_add_and_move(folio, lru_move_tail);
  }
  
-@@ -339,6 +435,12 @@ void lru_note_cost_refault(struct folio *folio)
+@@ -300,6 +396,12 @@ void lru_note_cost_refault(struct folio *folio)
  				folio_nr_pages(folio), 0);
  }
  
@@ -11604,7 +11596,7 @@ index 588f50d8f1..ec05a13949 100644
  static void lru_activate(struct lruvec *lruvec, struct folio *folio)
  {
  	long nr_pages = folio_nr_pages(folio);
-@@ -346,10 +448,24 @@ static void lru_activate(struct lruvec *lruvec, struct folio *folio)
+@@ -307,10 +409,24 @@ static void lru_activate(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_active(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11630,7 +11622,7 @@ index 588f50d8f1..ec05a13949 100644
  	trace_mm_lru_activate(folio);
  
  	__count_vm_events(PGACTIVATE, nr_pages);
-@@ -371,6 +487,13 @@ void folio_activate(struct folio *folio)
+@@ -332,6 +448,13 @@ void folio_activate(struct folio *folio)
  	    !folio_test_lru(folio))
  		return;
  
@@ -11644,7 +11636,7 @@ index 588f50d8f1..ec05a13949 100644
  	folio_batch_add_and_move(folio, lru_activate);
  }
  
-@@ -386,6 +509,15 @@ void folio_activate(struct folio *folio)
+@@ -347,6 +470,15 @@ void folio_activate(struct folio *folio)
  	if (!folio_test_clear_lru(folio))
  		return;
  
@@ -11659,8 +11651,8 @@ index 588f50d8f1..ec05a13949 100644
 +
  	lruvec = folio_lruvec_lock_irq(folio);
  	lru_activate(lruvec, folio);
- 	lruvec_unlock_irq(lruvec);
-@@ -501,6 +633,32 @@ void folio_mark_accessed(struct folio *folio)
+ 	unlock_page_lruvec_irq(lruvec);
+@@ -460,6 +592,32 @@ void folio_mark_accessed(struct folio *folio)
  		lru_gen_inc_refs(folio);
  		return;
  	}
@@ -11693,11 +11685,10 @@ index 588f50d8f1..ec05a13949 100644
  
  	if (!folio_test_referenced(folio)) {
  		folio_set_referenced(folio);
-@@ -544,6 +702,30 @@ void folio_add_lru(struct folio *folio)
- 			folio_test_unevictable(folio), folio);
+@@ -504,9 +662,24 @@ void folio_add_lru(struct folio *folio)
  	VM_BUG_ON_FOLIO(folio_test_lru(folio), folio);
  
-+	/* see the comment in lru_gen_folio_seq() */
+ 	/* see the comment in lru_gen_folio_seq() */
 +#ifdef CONFIG_LRU_MARIE
 +	/*
 +	 * Marie bypass: Marie tracks folios via per-PFN state bytes,
@@ -11707,32 +11698,19 @@ index 588f50d8f1..ec05a13949 100644
 +	 * VM_BUG_ON_FOLIO(folio_test_active(folio), folio) in
 +	 * mm/vmscan.c. Skip the MGLRU fault hint when Marie owns
 +	 * the LRU. (See also defensive clear in lru_marie_add_folio.)
-+	 *
-+	 * Otherwise apply the 7.2 fault hint: refaulted workingset
-+	 * folios get PG_active; not-yet-referenced (prefaulted file)
-+	 * folios get folio_mark_accessed() -> PG_referenced so
-+	 * lru_gen_folio_seq() places them into the second oldest gen.
 +	 */
 +	if (!lru_marie_enabled() && lru_gen_enabled() && !folio_test_unevictable(folio) &&
-+	    lru_gen_in_fault() && !(current->flags & PF_MEMALLOC)) {
-+		if (folio_test_workingset(folio))
-+			folio_set_active(folio);
-+		else if (!folio_test_referenced(folio))
-+			folio_mark_accessed(folio);
-+	}
++	    lru_gen_in_fault() && !(current->flags & PF_MEMALLOC))
++		folio_set_active(folio);
 +#else
- 	/*
- 	 * For refaulted workingset folios, set PG_active so they
- 	 * can be added to active generations.
-@@ -558,6 +740,7 @@ void folio_add_lru(struct folio *folio)
- 		else if (!folio_test_referenced(folio))
- 			folio_mark_accessed(folio);
- 	}
+ 	if (lru_gen_enabled() && !folio_test_unevictable(folio) &&
+ 	    lru_gen_in_fault() && !(current->flags & PF_MEMALLOC))
+ 		folio_set_active(folio);
 +#endif
  
  	folio_batch_add_and_move(folio, lru_add);
  }
-@@ -614,6 +797,11 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
+@@ -563,6 +736,11 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
  	if (folio_mapped(folio))
  		return;
  
@@ -11744,7 +11722,7 @@ index 588f50d8f1..ec05a13949 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	folio_clear_referenced(folio);
-@@ -625,14 +813,24 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
+@@ -574,14 +752,24 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
  		 * race window is _really_ small and  it's not a critical
  		 * problem.
  		 */
@@ -11771,7 +11749,7 @@ index 588f50d8f1..ec05a13949 100644
  		__count_vm_events(PGROTATED, nr_pages);
  	}
  
-@@ -650,10 +848,20 @@ static void lru_deactivate(struct lruvec *lruvec, struct folio *folio)
+@@ -599,10 +787,20 @@ static void lru_deactivate(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_unevictable(folio) || !(folio_test_active(folio) || lru_gen_enabled()))
  		return;
  
@@ -11793,7 +11771,7 @@ index 588f50d8f1..ec05a13949 100644
  
  	__count_vm_events(PGDEACTIVATE, nr_pages);
  	count_memcg_events(lruvec_memcg(lruvec), PGDEACTIVATE, nr_pages);
-@@ -667,6 +875,11 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
+@@ -616,6 +814,11 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
  	    folio_test_swapcache(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11805,7 +11783,7 @@ index 588f50d8f1..ec05a13949 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	if (lru_gen_enabled())
-@@ -679,7 +892,12 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
+@@ -628,7 +831,12 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
  	 * anonymous folios
  	 */
  	folio_clear_swapbacked(folio);
@@ -11819,7 +11797,7 @@ index 588f50d8f1..ec05a13949 100644
  
  	__count_vm_events(PGLAZYFREE, nr_pages);
  	count_memcg_events(lruvec_memcg(lruvec), PGLAZYFREE, nr_pages);
-@@ -743,6 +961,13 @@ void deactivate_file_folio(struct folio *folio)
+@@ -692,6 +900,13 @@ void deactivate_file_folio(struct folio *folio)
  	if (lru_gen_enabled() && lru_gen_clear_refs(folio))
  		return;
  
@@ -11833,7 +11811,7 @@ index 588f50d8f1..ec05a13949 100644
  	folio_batch_add_and_move(folio, lru_deactivate_file);
  }
  
-@@ -762,6 +987,13 @@ void folio_deactivate(struct folio *folio)
+@@ -711,6 +926,13 @@ void folio_deactivate(struct folio *folio)
  	if (lru_gen_enabled() ? lru_gen_clear_refs(folio) : !folio_test_active(folio))
  		return;
  
@@ -11847,7 +11825,7 @@ index 588f50d8f1..ec05a13949 100644
  	folio_batch_add_and_move(folio, lru_deactivate);
  }
  
-@@ -779,6 +1011,14 @@ void folio_mark_lazyfree(struct folio *folio)
+@@ -728,6 +950,14 @@ void folio_mark_lazyfree(struct folio *folio)
  	    folio_test_swapcache(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11863,10 +11841,10 @@ index 588f50d8f1..ec05a13949 100644
  }
  
 diff --git a/mm/swap.h b/mm/swap.h
-index 77d2d14eda..4b915f45e1 100644
+index c6bdc5d215..95edddea04 100644
 --- a/mm/swap.h
 +++ b/mm/swap.h
-@@ -251,6 +251,10 @@ static inline void swap_read_unplug(struct swap_iocb *plug)
+@@ -196,6 +196,10 @@ static inline void swap_read_unplug(struct swap_iocb *plug)
  void swap_write_unplug(struct swap_iocb *sio);
  int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug);
  void __swap_writepage(struct folio *folio, struct swap_iocb **swap_plug);
@@ -11878,7 +11856,7 @@ index 77d2d14eda..4b915f45e1 100644
  /* linux/mm/swap_state.c */
  extern struct address_space swap_space __read_mostly;
 diff --git a/mm/vmscan.c b/mm/vmscan.c
-index 35c3bb15ae..6a4412e5d2 100644
+index 95b1179a14..de1437b29b 100644
 --- a/mm/vmscan.c
 +++ b/mm/vmscan.c
 @@ -39,6 +39,7 @@
@@ -11889,7 +11867,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  #include <linux/migrate.h>
  #include <linux/delayacct.h>
  #include <linux/sysctl.h>
-@@ -179,6 +180,34 @@ struct scan_control {
+@@ -182,6 +183,34 @@ struct scan_control {
  	struct reclaim_state reclaim_state;
  };
  
@@ -11924,14 +11902,14 @@ index 35c3bb15ae..6a4412e5d2 100644
  #ifdef ARCH_HAS_PREFETCHW
  #define prefetchw_prev_lru_folio(_folio, _base, _field)			\
  	do {								\
-@@ -456,6 +485,44 @@ static int reclaimer_offset(struct scan_control *sc)
+@@ -479,6 +508,45 @@ static int reclaimer_offset(struct scan_control *sc)
  	return PGSTEAL_DIRECT - PGSTEAL_KSWAPD;
  }
  
 +#ifdef CONFIG_LRU_MARIE
 +/*
 + * Wrapper used by mm/lru_marie, which sees @sc but not the static
-+ * reclaimer_offset() above. On 6.18+/7.x reclaimer_offset() takes @sc, so
++ * reclaimer_offset() above. On 6.18+ reclaimer_offset() takes @sc, so
 + * forward it.
 + */
 +int vmscan_reclaimer_offset(struct scan_control *sc)
@@ -11966,10 +11944,11 @@ index 35c3bb15ae..6a4412e5d2 100644
 +	return can_reclaim_anon_pages(memcg, nid, sc);
 +}
 +#endif
- /*
-  * We detected a synchronous write error writing a folio out.  Probably
-  * -ENOSPC.  We need to propagate that into the address_space for a subsequent
-@@ -874,10 +941,7 @@ static enum folio_references folio_check_references(struct folio *folio,
++
+ static inline int is_page_cache_freeable(struct folio *folio)
+ {
+ 	/*
+@@ -922,10 +990,7 @@ static enum folio_references folio_check_references(struct folio *folio,
  		return FOLIOREF_ACTIVATE;
  
  	/*
@@ -11981,7 +11960,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  	 */
  	if (referenced_ptes == -1)
  		return FOLIOREF_KEEP;
-@@ -891,6 +955,30 @@ static enum folio_references folio_check_references(struct folio *folio,
+@@ -939,6 +1004,30 @@ static enum folio_references folio_check_references(struct folio *folio,
  
  	referenced_folio = folio_test_clear_referenced(folio);
  
@@ -12012,7 +11991,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  	if (referenced_ptes) {
  		/*
  		 * All mapped folios start out with page table
-@@ -1050,9 +1138,13 @@ static bool may_enter_fs(struct folio *folio, gfp_t gfp_mask)
+@@ -1104,9 +1193,13 @@ static bool may_enter_fs(struct folio *folio, gfp_t gfp_mask)
  }
  
  /*
@@ -12028,10 +12007,10 @@ index 35c3bb15ae..6a4412e5d2 100644
  		struct pglist_data *pgdat, struct scan_control *sc,
  		struct reclaim_stat *stat, bool ignore_references,
  		struct mem_cgroup *memcg)
-@@ -1913,7 +2005,29 @@ static unsigned int move_folios_to_lru(struct list_head *list)
- 			continue;
- 		}
- 
+@@ -1981,7 +2074,29 @@ static unsigned int move_folios_to_lru(struct lruvec *lruvec,
+ 		 * inhibits memcg migration).
+ 		 */
+ 		VM_BUG_ON_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
 -		lruvec_add_folio(lruvec, folio);
 +#ifdef CONFIG_LRU_MARIE
 +		/*
@@ -12059,7 +12038,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  		nr_pages = folio_nr_pages(folio);
  		nr_moved += nr_pages;
  		if (folio_test_active(folio))
-@@ -5262,6 +5376,55 @@ static bool drain_evictable(struct lruvec *lruvec)
+@@ -5201,6 +5316,55 @@ static bool drain_evictable(struct lruvec *lruvec)
  	return true;
  }
  
@@ -12115,7 +12094,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  static void lru_gen_change_state(bool enabled)
  {
  	static DEFINE_MUTEX(state_mutex);
-@@ -5783,7 +5946,15 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
+@@ -5723,7 +5887,15 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
  	struct lru_gen_mm_state *mm_state = get_mm_state(lruvec);
  
  	lrugen->max_seq = MIN_NR_GENS + 1;
@@ -12132,7 +12111,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  
  	for (i = 0; i <= MIN_NR_GENS + 1; i++)
  		lrugen->timestamps[i] = jiffies;
-@@ -5883,7 +6054,23 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
+@@ -5823,7 +5995,23 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
  	unsigned long nr_to_reclaim = sc->nr_to_reclaim;
  	bool proportional_reclaim;
  	struct blk_plug plug;
@@ -12145,18 +12124,18 @@ index 35c3bb15ae..6a4412e5d2 100644
 +		marie_drain_mask = lru_marie_shrink_lruvec(lruvec, sc);
 +		/*
 +		 * Fall through to the legacy reclaim path below to drain orphan
-+		 * folios (failed Marie install) that landed on lruvec->lists;
-+		 * MGLRU is bypassed under Marie. The drain is constrained by
-+		 * marie_drain_mask below so it touches only the type(s) Marie
-+		 * scanned. Common case: the lists are empty and this is a cheap
-+		 * no-op.
++		 * folios (failed Marie install, drain/reparent handoffs) that
++		 * landed on lruvec->lists; MGLRU is bypassed under Marie. The
++		 * drain is constrained by marie_drain_mask below so it touches
++		 * only the type(s) Marie scanned. Common case: the lists are
++		 * empty and this is a cheap no-op.
 +		 */
 +	} else
 +#endif
- 	if ((lru_gen_enabled() || lru_gen_switching()) && !root_reclaim(sc)) {
+ 	if (lru_gen_enabled() && !root_reclaim(sc)) {
  		lru_gen_shrink_lruvec(lruvec, sc);
- 
-@@ -5894,6 +6081,29 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
+ 		return;
+@@ -5831,6 +6019,29 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
  
  	get_scan_count(lruvec, sc, nr);
  
@@ -12186,11 +12165,10 @@ index 35c3bb15ae..6a4412e5d2 100644
  	/* Record the original scan target for proportional adjustments later */
  	memcpy(targets, nr, sizeof(nr));
  
-@@ -6149,14 +6359,32 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
+@@ -6086,11 +6297,26 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
  	struct lruvec *target_lruvec;
  	bool reclaimable = false;
  
--	if ((lru_gen_enabled() || lru_gen_switching()) && root_reclaim(sc)) {
 +#ifdef CONFIG_LRU_MARIE
 +	/*
 +	 * MGLRU's root-reclaim shortcut bypasses shrink_node_memcgs entirely,
@@ -12200,27 +12178,21 @@ index 35c3bb15ae..6a4412e5d2 100644
 +	 * at all.  Gate the shortcut on !lru_marie_enabled() so kswapd takes the
 +	 * standard shrink_node_memcgs path under Marie.
 +	 */
-+	if (!lru_marie_enabled() &&
-+	    (lru_gen_enabled() || lru_gen_switching()) && root_reclaim(sc)) {
- 		memset(&sc->nr, 0, sizeof(sc->nr));
- 		lru_gen_shrink_node(pgdat, sc);
- 
- 		if (!lru_gen_switching())
- 			return;
++	if (!lru_marie_enabled() && lru_gen_enabled() && root_reclaim(sc)) {
++		lru_gen_shrink_node(pgdat, sc);
++		return;
 +	}
 +#else
-+	if ((lru_gen_enabled() || lru_gen_switching()) && root_reclaim(sc)) {
-+		memset(&sc->nr, 0, sizeof(sc->nr));
-+		lru_gen_shrink_node(pgdat, sc);
- 
-+		if (!lru_gen_switching())
-+			return;
+ 	if (lru_gen_enabled() && root_reclaim(sc)) {
+ 		memset(&sc->nr, 0, sizeof(sc->nr));
+ 		lru_gen_shrink_node(pgdat, sc);
+ 		return;
  	}
 +#endif
  
  	target_lruvec = mem_cgroup_lruvec(sc->target_mem_cgroup, pgdat);
  
-@@ -6425,6 +6653,17 @@ static void snapshot_refaults(struct mem_cgroup *target_memcg, pg_data_t *pgdat)
+@@ -6364,6 +6590,17 @@ static void snapshot_refaults(struct mem_cgroup *target_memcg, pg_data_t *pgdat)
  	struct lruvec *target_lruvec;
  	unsigned long refaults;
  
@@ -12235,10 +12207,10 @@ index 35c3bb15ae..6a4412e5d2 100644
 +		return;
 +#endif
 +
- 	if (lru_gen_enabled() && !lru_gen_switching())
+ 	if (lru_gen_enabled())
  		return;
  
-@@ -6815,6 +7054,21 @@ static void kswapd_age_node(struct pglist_data *pgdat, struct scan_control *sc)
+@@ -6760,6 +6997,21 @@ static void kswapd_age_node(struct pglist_data *pgdat, struct scan_control *sc)
  	struct mem_cgroup *memcg;
  	struct lruvec *lruvec;
  
@@ -12257,10 +12229,10 @@ index 35c3bb15ae..6a4412e5d2 100644
 +	}
 +#endif
 +
- 	if (lru_gen_enabled() || lru_gen_switching()) {
+ 	if (lru_gen_enabled()) {
  		lru_gen_age_node(pgdat, sc);
- 
-@@ -7593,6 +7847,9 @@ unsigned long shrink_all_memory(unsigned long nr_to_reclaim)
+ 		return;
+@@ -7504,6 +7756,9 @@ unsigned long shrink_all_memory(unsigned long nr_to_reclaim)
  void __meminit kswapd_run(int nid)
  {
  	pg_data_t *pgdat = NODE_DATA(nid);
@@ -12270,7 +12242,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  
  	pgdat_kswapd_lock(pgdat);
  	if (!pgdat->kswapd) {
-@@ -7606,7 +7863,32 @@ void __meminit kswapd_run(int nid)
+@@ -7517,7 +7772,32 @@ void __meminit kswapd_run(int nid)
  		} else {
  			wake_up_process(pgdat->kswapd);
  		}
@@ -12303,7 +12275,7 @@ index 35c3bb15ae..6a4412e5d2 100644
  	pgdat_kswapd_unlock(pgdat);
  }
  
-@@ -7625,16 +7907,52 @@ void __meminit kswapd_stop(int nid)
+@@ -7536,16 +7816,52 @@ void __meminit kswapd_stop(int nid)
  		kthread_stop(kswapd);
  		pgdat->kswapd = NULL;
  	}

--- a/patches/testing/0001-linux7.0-lru_marie-0.7.8.patch
+++ b/patches/testing/0001-linux7.0-lru_marie-0.7.8.patch
@@ -1,7 +1,7 @@
 From aa78c519a3f99a5181a805b4233430ca2798775a Mon Sep 17 00:00:00 2001
 From: Masahito S <firelzrd@gmail.com>
 Date: Mon, 13 Jul 2026 01:28:36 +0900
-Subject: [PATCH] linux7.0-lru_marie-0.7.7
+Subject: [PATCH] linux7.0-lru_marie-0.7.8
 
 ---
  include/linux/lru_marie.h      |  493 ++++++
@@ -30,7 +30,7 @@ Subject: [PATCH] linux7.0-lru_marie-0.7.7
  mm/lru_marie/simd_x86_avx2.S   |  152 ++
  mm/lru_marie/simd_x86_avx512.S |  199 +++
  mm/lru_marie/simd_x86_sse2.S   |  158 ++
- mm/lru_marie/state.c           | 3014 ++++++++++++++++++++++++++++++++
+ mm/lru_marie/state.c           | 3013 ++++++++++++++++++++++++++++++++
  mm/lru_marie/state.h           |  987 +++++++++++
  mm/lru_marie/state_compat.h    |   94 +
  mm/lru_marie/version.h         |   22 +
@@ -46,7 +46,7 @@ Subject: [PATCH] linux7.0-lru_marie-0.7.7
  mm/swap.c                      |  248 ++-
  mm/swap.h                      |    4 +
  mm/vmscan.c                    |  331 +++-
- 42 files changed, 11366 insertions(+), 27 deletions(-)
+ 42 files changed, 11365 insertions(+), 27 deletions(-)
  create mode 100644 include/linux/lru_marie.h
  create mode 100644 mm/lru_marie/Makefile
  create mode 100644 mm/lru_marie/account.h
@@ -246,7 +246,7 @@ index 0000000000..fc30269822
 + * to enter the buddy allocator. When marie_state[pfn] still carries
 + * TRACKED -- which happens whenever the reclaim isolate path
 + * (marie_evict_counters_only) decremented counters but intentionally
-+ * preserved the state byte so install_local's TRACKED early-out kept
++ * preserved the state byte so marie_folio_install's TRACKED early-out kept
 + * blocking concurrent installs during shrink_folio_list -- this wipes
 + * the byte, the global (type, gen, tier) bitmap bit, and the
 + * gen_occupied slot in one lock-free pass.
@@ -1663,7 +1663,7 @@ index 0000000000..e2feeee275
 + *     no per-(lru, zone) shadow counter to bounce
 + *   - per-pgdat walker driven from kswapd, with rmap-fed bloom
 + *     feedback so PMD scans concentrate on hot regions
-+ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 4)
++ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 8)
 + *     encoded in the per-PFN byte, advanced by global install cadence
 + *     (marie_folio_install counts installs onto the head gen and
 + *     advances at marie_gen_growth_live[type])
@@ -1869,14 +1869,14 @@ index 0000000000..e2feeee275
 + *   - lru_marie_add_folio always lands on the current head gen
 + *     (atomic_read(&marie_head_gen[type])).
 + *   - marie_state_isolate_scan_l2lock always pulls from the oldest
-+ *     occupied gen (marie_find_oldest_occupied).
++ *     occupied gen (marie_find_oldest_occupied_mlv).
 + *   - shrink_folio_list classifies each isolated folio:
 + *       FOLIOREF_RECLAIM  → freed (this folio truly was cold)
 + *       FOLIOREF_KEEP     → returned in folio_list, putback re-routes
 + *       FOLIOREF_ACTIVATE → ditto, with PG_active set
-+ *     putback re-installs the survivor at (oldest+1)&3 with
++ *     putback re-installs the survivor at (oldest+1)&7 with
 + *     target_tier = max(prev_tier, w_tier) via
-+ *     marie_install_at_gen.
++ *     marie_state_publish_at_gen.
 + *   - head_gen advances per type via marie_try_advance_head_mlv (the
 + *     _mlv suffix is historical -- the clock is a single global one per
 + *     type), fired by global install cadence alone (marie_folio_install
@@ -5395,7 +5395,7 @@ new file mode 100644
 index 0000000000..4acf8318d6
 --- /dev/null
 +++ b/mm/lru_marie/state.c
-@@ -0,0 +1,3014 @@
+@@ -0,0 +1,3013 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Marie per-PFN state array — allocation, init, and global counters.
@@ -6235,7 +6235,7 @@ index 0000000000..4acf8318d6
 + * between marie_evict_counters_only (counters -1, TRACKED preserved) and
 + * the next allocation at the same PFN: the moment the page is destined
 + * for buddy, we wipe Marie's per-PFN bookkeeping so a subsequent
-+ * install_local starts from a clean state byte.
++ * marie_folio_install starts from a clean state byte.
 + *
 + * Counters are NOT touched here -- they were either already balanced
 + * by marie_evict_locked (the normal Marie del path) or pre-decremented
@@ -6458,9 +6458,9 @@ index 0000000000..4acf8318d6
 + * encodes (target_gen, target_tier).
 + *
 + * Called from:
-+ *   marie_state_inc_tier saturate path (target_gen=head, target_tier=0)
-+ *   shrink_lruvec residue putback (target_gen=(head+2)&3,
-+ *                                  target_tier=max(prev, w_tier))
++ *   marie_folio_demote / lru_marie_lazyfree (MADV_COLD / MADV_FREE),
++ *   both as (target_gen=oldest, target_tier=0). The tier-saturate
++ *   roll is open-coded inline in __marie_state_inc_tier instead.
 + */
 +void marie_state_move_to_gen(unsigned long pfn,
 +			     u8 target_gen, u8 target_tier)
@@ -6791,7 +6791,7 @@ index 0000000000..4acf8318d6
 +			    unsigned long nr_reclaimed,
 +			    u8 swappiness)
 +{
-+	s64 cur, delta;
++	s64 delta;
 +
 +	/*
 +	 * Special values bypass the controller. The pick path does not
@@ -6817,8 +6817,7 @@ index 0000000000..4acf8318d6
 +	else
 +		delta = +(s64)nr_reclaimed * (s64)swappiness;
 +
-+	cur = atomic64_read(&marie_swap_bias);
-+	atomic64_set(&marie_swap_bias, cur + delta);
++	atomic64_add(delta, &marie_swap_bias);
 +}
 +
 +/*
@@ -6993,7 +6992,7 @@ index 0000000000..4acf8318d6
 + * reclaim-driven trigger, fired ONLY on true exhaustion (the retired
 + * unconditional "occupied < 2 at entry" form thrashed the ring). Without
 + * demand-pull a workload that stops installing a type strands its
-+ * head-gen pages, since marie_find_oldest_occupied skips head (the
++ * head-gen pages, since marie_find_oldest_occupied_mlv skips head (the
 + * install destination).
 + *
 + * Per (type, tier) the scan walks the per-(gen, type) bitmap, claims
@@ -7001,7 +7000,7 @@ index 0000000000..4acf8318d6
 + * marie_evict_counters_only: counters decremented and the scan-bitmap
 + * slot + gen_occupied retired at isolate (so other CPUs stop re-finding
 + * the in-flight folio), but the per-PFN TRACKED byte is KEPT so
-+ * install_local's early-out blocks a concurrent install from re-setting
++ * marie_folio_install's early-out blocks a concurrent install from re-setting
 + * PG_lru while shrink_folio_list reclaims it.
 + *
 + * Teardown of the TRACKED byte is deferred: a reclaimed folio is wiped
@@ -7443,7 +7442,7 @@ index 0000000000..4acf8318d6
 +					 * counters AND retires the scan-bitmap
 +					 * slot (so other CPUs stop re-finding
 +					 * this in-flight folio), but KEEPS the
-+					 * TRACKED byte so install_local's early-
++					 * TRACKED byte so marie_folio_install's early-
 +					 * out blocks any concurrent install from
 +					 * re-setting PG_lru while shrink_folio_-
 +					 * list reclaims it. The TRACKED byte is
@@ -8111,7 +8110,7 @@ index 0000000000..4acf8318d6
 + *   1. folio_try_get()        - reference held, folio cannot be freed.
 + *   2. folio_test_clear_lru() - PG_lru cleared atomically, gating
 + *                                external del paths.
-+ *   3. install_local TRACKED early-out (above)
++ *   3. marie_folio_install TRACKED early-out (above)
 + *
 + * memcg_bitmap is cleared here because the buddy free hook
 + * (marie_state_drop_pfn_at_free) runs without a folio reference and cannot
@@ -8768,7 +8767,7 @@ index 0000000000..585bea9c8e
 +/*
 + * clean_min_ratio: minimum file-pagecache reserve as percent of
 + * node_present_pages. Sysfs-tunable in core.c, read by reclaim.
-+ * Default 15 (le9uo recommendation for desktop).
++ * Default 10.
 + */
 +extern unsigned int marie_clean_min_ratio;
 +
@@ -8918,11 +8917,11 @@ index 0000000000..585bea9c8e
 + * counter updates on both source and destination (gen, type) planes.
 + *
 + * Single point of policy for any operation that needs to move a folio
-+ * between gens. Two callers in design.h:
-+ *   - walker tier saturate (section 7):
-+ *       marie_state_move_to_gen(pfn, head, 0)
-+ *   - shrink_folio_list residue putback (section 13):
-+ *       marie_state_move_to_gen(pfn, (head + 2) & 3, max(prev, w))
++ * between gens. Callers (all in state.c):
++ *   - MADV_COLD demote (marie_folio_demote):
++ *       marie_state_move_to_gen(pfn, oldest, 0)
++ *   - MADV_FREE (lru_marie_lazyfree): same (pfn, oldest, 0) form.
++ *     (The reclaim putback now uses marie_state_publish_at_gen.)
 + *
 + * The state-byte cmpxchg defeats races against del / another
 + * concurrent move. The bitmap / counter shuffle uses "new first, then
@@ -8940,9 +8939,9 @@ index 0000000000..585bea9c8e
 + * marie_state_drop_pfn - wipe every per-PFN tracking artifact
 + * (state byte, (type, gen, tier) L1 bit, occupancy counter, global
 + * L2 range counter with bulk L2 clear on 0) for @folio. Shared by the
-+ * normal evict path (marie_evict_locked) and the enable=0 drain path
-+ * (marie_drain_one_lruvec) so disable->enable cycles never leave
-+ * ghost per-PFN state behind. No-op when the byte is not TRACKED.
++ * normal evict path (marie_evict_locked) -- the runtime enable=0
++ * drain that used to share it was removed together with the boot-only
++ * static key. No-op when the byte is not TRACKED.
 + */
 +void marie_state_drop_pfn(struct folio *folio);
 +
@@ -9308,14 +9307,14 @@ index 0000000000..585bea9c8e
 + * ---------------------------------------------------------------------
 + *
 + * No promote-queue or per-CPU staging drain remains: every install /
-+ * evict / tier bump is synchronous (install_local / install_locked
-+ * publish per-PFN state inline, evict_locked wipes it inline,
-+ * marie_state_inc_tier handles saturation via marie_state_move_to_gen
-+ * directly).
++ * evict / tier bump is synchronous (marie_folio_install publishes
++ * per-PFN state inline, marie_evict_locked wipes it inline,
++ * marie_state_inc_tier handles saturation via an inline gen roll in
++ * __marie_state_inc_tier).
 + *
-+ * The remaining drain entry, marie_drain_one_lruvec (in core.c), is
-+ * only the enable/disable transition: it walks the per-(type, gen,
-+ * tier) bitmap and hands every TRACKED folio back to the legacy LRU.
++ * No enable/disable drain entry remains either: Marie is selected
++ * once at boot via the lru_marie= static key, before any folio is
++ * tracked, so there is nothing to hand back to the legacy LRU.
 + */
 +
 +/*
@@ -9528,7 +9527,7 @@ index 0000000000..8edb82807a
 +#define MARIE_PROGNAME	"Marie LRU"
 +#define MARIE_AUTHOR	"Masahito Suzuki"
 +
-+#define MARIE_VERSION	"0.7.7"
++#define MARIE_VERSION	"0.7.8"
 +
 +#endif /* _MM_LRU_MARIE_VERSION_H */
 diff --git a/mm/lru_marie/walker.c b/mm/lru_marie/walker.c
@@ -11025,7 +11024,7 @@ index 2d4b6f1a55..daa2311ace 100644
 +	/*
 +	 * Wipe Marie's per-PFN state at the buddy handoff. Marie's reclaim
 +	 * isolate path intentionally leaves marie_state[pfn]'s TRACKED bit
-+	 * set across shrink_folio_list (so install_local's TRACKED early-
++	 * set across shrink_folio_list (so marie_folio_install's TRACKED early-
 +	 * out keeps blocking concurrent installs on the in-flight folio);
 +	 * this hook is the canonical point at which that stale bit must
 +	 * disappear so the next allocation at this PFN starts clean. No-op

--- a/patches/testing/0001-linux7.1-rc5-lru_marie-0.7.8.patch
+++ b/patches/testing/0001-linux7.1-rc5-lru_marie-0.7.8.patch
@@ -1,13 +1,13 @@
-From 831da586774ef91479f6b11e2629e0ff144910ed Mon Sep 17 00:00:00 2001
+From 781c580b033d8d14121be6739173bee70d734ff9 Mon Sep 17 00:00:00 2001
 From: Masahito S <firelzrd@gmail.com>
 Date: Mon, 13 Jul 2026 01:28:36 +0900
-Subject: [PATCH] linux6.18.22-lru_marie-0.7.7
+Subject: [PATCH] linux7.1-rc5-lru_marie-0.7.8
 
 ---
  include/linux/lru_marie.h      |  493 ++++++
  include/linux/memcontrol.h     |   26 +-
  include/linux/mm_inline.h      |  103 +-
- include/linux/mmzone.h         |   16 +
+ include/linux/mmzone.h         |   15 +
  include/linux/swap.h           |   18 +
  mm/Kconfig                     |   54 +
  mm/Makefile                    |    1 +
@@ -30,23 +30,23 @@ Subject: [PATCH] linux6.18.22-lru_marie-0.7.7
  mm/lru_marie/simd_x86_avx2.S   |  152 ++
  mm/lru_marie/simd_x86_avx512.S |  199 +++
  mm/lru_marie/simd_x86_sse2.S   |  158 ++
- mm/lru_marie/state.c           | 3014 ++++++++++++++++++++++++++++++++
+ mm/lru_marie/state.c           | 3013 ++++++++++++++++++++++++++++++++
  mm/lru_marie/state.h           |  987 +++++++++++
  mm/lru_marie/state_compat.h    |   94 +
  mm/lru_marie/version.h         |   22 +
  mm/lru_marie/walker.c          |  969 ++++++++++
  mm/lru_marie/walker_compat.h   |   82 +
  mm/memcontrol-v1.c             |   11 +
- mm/memcontrol.c                |   13 +
+ mm/memcontrol.c                |   21 +
  mm/mm_init.c                   |    3 +
- mm/oom_kill.c                  |  308 ++++
+ mm/oom_kill.c                  |  305 ++++
  mm/page_alloc.c                |  120 +-
  mm/page_io.c                   |  187 ++
  mm/rmap.c                      |    6 +
  mm/swap.c                      |  248 ++-
  mm/swap.h                      |    4 +
- mm/vmscan.c                    |  332 +++-
- 42 files changed, 11367 insertions(+), 27 deletions(-)
+ mm/vmscan.c                    |  336 +++-
+ 42 files changed, 11373 insertions(+), 28 deletions(-)
  create mode 100644 include/linux/lru_marie.h
  create mode 100644 mm/lru_marie/Makefile
  create mode 100644 mm/lru_marie/account.h
@@ -246,7 +246,7 @@ index 0000000000..fc30269822
 + * to enter the buddy allocator. When marie_state[pfn] still carries
 + * TRACKED -- which happens whenever the reclaim isolate path
 + * (marie_evict_counters_only) decremented counters but intentionally
-+ * preserved the state byte so install_local's TRACKED early-out kept
++ * preserved the state byte so marie_folio_install's TRACKED early-out kept
 + * blocking concurrent installs during shrink_folio_list -- this wipes
 + * the byte, the global (type, gen, tier) bitmap bit, and the
 + * gen_occupied slot in one lock-free pass.
@@ -571,12 +571,12 @@ index 0000000000..fc30269822
 +
 +#endif /* _LINUX_LRU_MARIE_H */
 diff --git a/include/linux/memcontrol.h b/include/linux/memcontrol.h
-index 1335911999..8cf24a1399 100644
+index dc3fa68775..bde5bd78ff 100644
 --- a/include/linux/memcontrol.h
 +++ b/include/linux/memcontrol.h
-@@ -898,14 +898,38 @@ static inline bool mem_cgroup_online(struct mem_cgroup *memcg)
+@@ -880,14 +880,38 @@ static inline bool mem_cgroup_online(struct mem_cgroup *memcg)
  void mem_cgroup_update_lru_size(struct lruvec *lruvec, enum lru_list lru,
- 		int zid, int nr_pages);
+ 		int zid, long nr_pages);
  
 +#ifdef CONFIG_LRU_MARIE
 +/*
@@ -615,7 +615,7 @@ index 1335911999..8cf24a1399 100644
  
  void __mem_cgroup_handle_over_high(gfp_t gfp_mask);
 diff --git a/include/linux/mm_inline.h b/include/linux/mm_inline.h
-index f6a2b2d200..3bc9367354 100644
+index a171070e15..4779a3b6b9 100644
 --- a/include/linux/mm_inline.h
 +++ b/include/linux/mm_inline.h
 @@ -5,6 +5,7 @@
@@ -626,7 +626,7 @@ index f6a2b2d200..3bc9367354 100644
  #include <linux/swap.h>
  #include <linux/string.h>
  #include <linux/userfaultfd_k.h>
-@@ -41,7 +42,22 @@ static __always_inline void __update_lru_size(struct lruvec *lruvec,
+@@ -36,7 +37,22 @@ static __always_inline void __update_lru_size(struct lruvec *lruvec,
  {
  	struct pglist_data *pgdat = lruvec_pgdat(lruvec);
  
@@ -648,10 +648,10 @@ index f6a2b2d200..3bc9367354 100644
 +#endif
  	WARN_ON_ONCE(nr_pages != (int)nr_pages);
  
- 	__mod_lruvec_state(lruvec, NR_LRU_BASE + lru, nr_pages);
-@@ -103,14 +119,14 @@ static __always_inline enum lru_list folio_lru_list(const struct folio *folio)
- #ifdef CONFIG_LRU_GEN
- 
+ 	mod_lruvec_state(lruvec, NR_LRU_BASE + lru, nr_pages);
+@@ -104,14 +120,14 @@ static inline bool lru_gen_switching(void)
+ 	return static_branch_unlikely(&lru_switch);
+ }
  #ifdef CONFIG_LRU_GEN_ENABLED
 -static inline bool lru_gen_enabled(void)
 +static inline bool lru_gen_core_enabled(void)
@@ -666,7 +666,7 @@ index f6a2b2d200..3bc9367354 100644
  {
  	DECLARE_STATIC_KEY_FALSE(lru_gen_caps[NR_LRU_GEN_CAPS]);
  
-@@ -118,11 +134,57 @@ static inline bool lru_gen_enabled(void)
+@@ -119,11 +135,57 @@ static inline bool lru_gen_enabled(void)
  }
  #endif
  
@@ -724,7 +724,7 @@ index f6a2b2d200..3bc9367354 100644
  static inline int lru_gen_from_seq(unsigned long seq)
  {
  	return seq % MAX_NR_GENS;
-@@ -311,11 +373,19 @@ static inline void folio_migrate_refs(struct folio *new, const struct folio *old
+@@ -312,6 +374,11 @@ static inline void folio_migrate_refs(struct folio *new, const struct folio *old
  }
  #else /* !CONFIG_LRU_GEN */
  
@@ -736,6 +736,8 @@ index f6a2b2d200..3bc9367354 100644
  static inline bool lru_gen_enabled(void)
  {
  	return false;
+@@ -322,6 +389,9 @@ static inline bool lru_gen_switching(void)
+ 	return false;
  }
  
 +static inline void lru_gen_fill_lruvec(struct lruvec *lruvec) { }
@@ -744,9 +746,9 @@ index f6a2b2d200..3bc9367354 100644
  static inline bool lru_gen_in_fault(void)
  {
  	return false;
-@@ -342,8 +412,23 @@ void lruvec_add_folio(struct lruvec *lruvec, struct folio *folio)
- {
- 	enum lru_list lru = folio_lru_list(folio);
+@@ -350,8 +420,23 @@ void lruvec_add_folio(struct lruvec *lruvec, struct folio *folio)
+ 
+ 	VM_WARN_ON_ONCE_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
  
 +#ifdef CONFIG_LRU_MARIE
 +	if (lru_marie_add_folio(lruvec, folio, false))
@@ -768,9 +770,9 @@ index f6a2b2d200..3bc9367354 100644
  
  	update_lru_size(lruvec, lru, folio_zonenum(folio),
  			folio_nr_pages(folio));
-@@ -356,8 +441,17 @@ void lruvec_add_folio_tail(struct lruvec *lruvec, struct folio *folio)
- {
- 	enum lru_list lru = folio_lru_list(folio);
+@@ -366,8 +451,17 @@ void lruvec_add_folio_tail(struct lruvec *lruvec, struct folio *folio)
+ 
+ 	VM_WARN_ON_ONCE_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
  
 +#ifdef CONFIG_LRU_MARIE
 +	if (lru_marie_add_folio(lruvec, folio, true))
@@ -786,9 +788,9 @@ index f6a2b2d200..3bc9367354 100644
  
  	update_lru_size(lruvec, lru, folio_zonenum(folio),
  			folio_nr_pages(folio));
-@@ -370,6 +464,11 @@ void lruvec_del_folio(struct lruvec *lruvec, struct folio *folio)
- {
- 	enum lru_list lru = folio_lru_list(folio);
+@@ -382,6 +476,11 @@ void lruvec_del_folio(struct lruvec *lruvec, struct folio *folio)
+ 
+ 	VM_WARN_ON_ONCE_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
  
 +#ifdef CONFIG_LRU_MARIE
 +	if (lru_marie_del_folio(lruvec, folio, false))
@@ -799,19 +801,18 @@ index f6a2b2d200..3bc9367354 100644
  		return;
  
 diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
-index 7fb7331c57..521d39f68f 100644
+index 9adb2ad21d..3dd56a3add 100644
 --- a/include/linux/mmzone.h
 +++ b/include/linux/mmzone.h
-@@ -23,6 +23,8 @@
- #include <linux/page-flags.h>
+@@ -24,6 +24,7 @@
  #include <linux/local_lock.h>
  #include <linux/zswap.h>
-+#include <linux/sizes.h>
+ #include <linux/sizes.h>
 +#include <linux/kfifo.h>
  #include <asm/page.h>
  
  /* Free memory management - zoned buddy allocator.  */
-@@ -1442,6 +1444,20 @@ typedef struct pglist_data {
+@@ -1529,6 +1530,20 @@ typedef struct pglist_data {
  
  	atomic_t kswapd_failures;	/* Number of 'reclaimed == 0' runs */
  
@@ -833,10 +834,10 @@ index 7fb7331c57..521d39f68f 100644
  	int kcompactd_max_order;
  	enum zone_type kcompactd_highest_zoneidx;
 diff --git a/include/linux/swap.h b/include/linux/swap.h
-index e818fbade1..e7b8b27ed6 100644
+index 7a09df6977..cb9d9acecb 100644
 --- a/include/linux/swap.h
 +++ b/include/linux/swap.h
-@@ -450,6 +450,24 @@ extern atomic_long_t nr_swap_pages;
+@@ -421,6 +421,24 @@ extern atomic_long_t nr_swap_pages;
  extern long total_swap_pages;
  extern atomic_t nr_rotate_swap;
  
@@ -862,10 +863,10 @@ index e818fbade1..e7b8b27ed6 100644
  static inline bool vm_swap_full(void)
  {
 diff --git a/mm/Kconfig b/mm/Kconfig
-index 76001e9ba0..585bc58f9b 100644
+index e8bf1e9e6a..9de11ccbdc 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
-@@ -1329,6 +1329,60 @@ config LRU_GEN_WALKS_MMU
+@@ -1396,6 +1396,60 @@ config LRU_GEN_WALKS_MMU
  	depends on LRU_GEN && ARCH_HAS_HW_PTE_YOUNG
  # }
  
@@ -927,7 +928,7 @@ index 76001e9ba0..585bc58f9b 100644
         def_bool n
  
 diff --git a/mm/Makefile b/mm/Makefile
-index 21abb33535..f81f8c8be8 100644
+index 8ad2ab0824..1f8385ecee 100644
 --- a/mm/Makefile
 +++ b/mm/Makefile
 @@ -76,6 +76,7 @@ ifdef CONFIG_MMU
@@ -937,9 +938,9 @@ index 21abb33535..f81f8c8be8 100644
 +obj-$(CONFIG_LRU_MARIE)	+= lru_marie/
  obj-$(CONFIG_ZSWAP)	+= zswap.o
  obj-$(CONFIG_HAS_DMA)	+= dmapool.o
- obj-$(CONFIG_HUGETLBFS)	+= hugetlb.o
+ obj-$(CONFIG_HUGETLBFS)	+= hugetlb.o hugetlb_sysfs.o hugetlb_sysctl.o
 diff --git a/mm/compaction.c b/mm/compaction.c
-index 1e8f8eca31..972e79c836 100644
+index 3648ce22c8..3f0f769c1d 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -24,6 +24,7 @@
@@ -950,7 +951,7 @@ index 1e8f8eca31..972e79c836 100644
  #include "internal.h"
  
  #ifdef CONFIG_COMPACTION
-@@ -3075,6 +3076,23 @@ static void kcompactd_do_work(pg_data_t *pgdat)
+@@ -3092,6 +3093,23 @@ static void kcompactd_do_work(pg_data_t *pgdat)
  							cc.highest_zoneidx);
  	count_compact_event(KCOMPACTD_WAKE);
  
@@ -974,7 +975,7 @@ index 1e8f8eca31..972e79c836 100644
  	for (zoneid = 0; zoneid <= cc.highest_zoneidx; zoneid++) {
  		int status;
  
-@@ -3211,7 +3229,19 @@ static int kcompactd(void *p)
+@@ -3228,7 +3246,19 @@ static int kcompactd(void *p)
  			unsigned int prev_score, score;
  
  			prev_score = fragmentation_score_node(pgdat);
@@ -996,7 +997,7 @@ index 1e8f8eca31..972e79c836 100644
  			/*
  			 * Defer proactive compaction if the fragmentation
 diff --git a/mm/huge_memory.c b/mm/huge_memory.c
-index 8218e9d188..6b11aa0d70 100644
+index 970e077019..8ba88176e3 100644
 --- a/mm/huge_memory.c
 +++ b/mm/huge_memory.c
 @@ -6,6 +6,7 @@
@@ -1007,7 +1008,7 @@ index 8218e9d188..6b11aa0d70 100644
  #include <linux/sched.h>
  #include <linux/sched/mm.h>
  #include <linux/sched/numa_balancing.h>
-@@ -3239,14 +3240,48 @@ static void lru_add_split_folio(struct folio *folio, struct folio *new_folio,
+@@ -3558,14 +3559,48 @@ static void lru_add_split_folio(struct folio *folio, struct folio *new_folio,
  		/* page reclaim is reclaiming a huge page */
  		VM_WARN_ON(folio_test_lru(folio));
  		folio_get(new_folio);
@@ -1059,10 +1060,10 @@ index 8218e9d188..6b11aa0d70 100644
  	}
  }
 diff --git a/mm/internal.h b/mm/internal.h
-index c80c6f566c..37721deb60 100644
+index 5a2ddcf68e..4f640c01f3 100644
 --- a/mm/internal.h
 +++ b/mm/internal.h
-@@ -532,12 +532,55 @@ extern unsigned long highest_memmap_pfn;
+@@ -625,12 +625,55 @@ extern unsigned long highest_memmap_pfn;
   */
  #define MAX_RECLAIM_RETRIES 16
  
@@ -1118,7 +1119,7 @@ index c80c6f566c..37721deb60 100644
  int user_proactive_reclaim(char *buf,
  			   struct mem_cgroup *memcg, pg_data_t *pgdat);
  
-@@ -595,6 +638,30 @@ struct alloc_context {
+@@ -693,6 +736,30 @@ struct alloc_context {
  	 */
  	enum zone_type highest_zoneidx;
  	bool spread_dirty_pages;
@@ -1663,7 +1664,7 @@ index 0000000000..e2feeee275
 + *     no per-(lru, zone) shadow counter to bounce
 + *   - per-pgdat walker driven from kswapd, with rmap-fed bloom
 + *     feedback so PMD scans concentrate on hot regions
-+ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 4)
++ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 8)
 + *     encoded in the per-PFN byte, advanced by global install cadence
 + *     (marie_folio_install counts installs onto the head gen and
 + *     advances at marie_gen_growth_live[type])
@@ -1869,14 +1870,14 @@ index 0000000000..e2feeee275
 + *   - lru_marie_add_folio always lands on the current head gen
 + *     (atomic_read(&marie_head_gen[type])).
 + *   - marie_state_isolate_scan_l2lock always pulls from the oldest
-+ *     occupied gen (marie_find_oldest_occupied).
++ *     occupied gen (marie_find_oldest_occupied_mlv).
 + *   - shrink_folio_list classifies each isolated folio:
 + *       FOLIOREF_RECLAIM  → freed (this folio truly was cold)
 + *       FOLIOREF_KEEP     → returned in folio_list, putback re-routes
 + *       FOLIOREF_ACTIVATE → ditto, with PG_active set
-+ *     putback re-installs the survivor at (oldest+1)&3 with
++ *     putback re-installs the survivor at (oldest+1)&7 with
 + *     target_tier = max(prev_tier, w_tier) via
-+ *     marie_install_at_gen.
++ *     marie_state_publish_at_gen.
 + *   - head_gen advances per type via marie_try_advance_head_mlv (the
 + *     _mlv suffix is historical -- the clock is a single global one per
 + *     type), fired by global install cadence alone (marie_folio_install
@@ -5395,7 +5396,7 @@ new file mode 100644
 index 0000000000..4acf8318d6
 --- /dev/null
 +++ b/mm/lru_marie/state.c
-@@ -0,0 +1,3014 @@
+@@ -0,0 +1,3013 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Marie per-PFN state array — allocation, init, and global counters.
@@ -6235,7 +6236,7 @@ index 0000000000..4acf8318d6
 + * between marie_evict_counters_only (counters -1, TRACKED preserved) and
 + * the next allocation at the same PFN: the moment the page is destined
 + * for buddy, we wipe Marie's per-PFN bookkeeping so a subsequent
-+ * install_local starts from a clean state byte.
++ * marie_folio_install starts from a clean state byte.
 + *
 + * Counters are NOT touched here -- they were either already balanced
 + * by marie_evict_locked (the normal Marie del path) or pre-decremented
@@ -6458,9 +6459,9 @@ index 0000000000..4acf8318d6
 + * encodes (target_gen, target_tier).
 + *
 + * Called from:
-+ *   marie_state_inc_tier saturate path (target_gen=head, target_tier=0)
-+ *   shrink_lruvec residue putback (target_gen=(head+2)&3,
-+ *                                  target_tier=max(prev, w_tier))
++ *   marie_folio_demote / lru_marie_lazyfree (MADV_COLD / MADV_FREE),
++ *   both as (target_gen=oldest, target_tier=0). The tier-saturate
++ *   roll is open-coded inline in __marie_state_inc_tier instead.
 + */
 +void marie_state_move_to_gen(unsigned long pfn,
 +			     u8 target_gen, u8 target_tier)
@@ -6791,7 +6792,7 @@ index 0000000000..4acf8318d6
 +			    unsigned long nr_reclaimed,
 +			    u8 swappiness)
 +{
-+	s64 cur, delta;
++	s64 delta;
 +
 +	/*
 +	 * Special values bypass the controller. The pick path does not
@@ -6817,8 +6818,7 @@ index 0000000000..4acf8318d6
 +	else
 +		delta = +(s64)nr_reclaimed * (s64)swappiness;
 +
-+	cur = atomic64_read(&marie_swap_bias);
-+	atomic64_set(&marie_swap_bias, cur + delta);
++	atomic64_add(delta, &marie_swap_bias);
 +}
 +
 +/*
@@ -6993,7 +6993,7 @@ index 0000000000..4acf8318d6
 + * reclaim-driven trigger, fired ONLY on true exhaustion (the retired
 + * unconditional "occupied < 2 at entry" form thrashed the ring). Without
 + * demand-pull a workload that stops installing a type strands its
-+ * head-gen pages, since marie_find_oldest_occupied skips head (the
++ * head-gen pages, since marie_find_oldest_occupied_mlv skips head (the
 + * install destination).
 + *
 + * Per (type, tier) the scan walks the per-(gen, type) bitmap, claims
@@ -7001,7 +7001,7 @@ index 0000000000..4acf8318d6
 + * marie_evict_counters_only: counters decremented and the scan-bitmap
 + * slot + gen_occupied retired at isolate (so other CPUs stop re-finding
 + * the in-flight folio), but the per-PFN TRACKED byte is KEPT so
-+ * install_local's early-out blocks a concurrent install from re-setting
++ * marie_folio_install's early-out blocks a concurrent install from re-setting
 + * PG_lru while shrink_folio_list reclaims it.
 + *
 + * Teardown of the TRACKED byte is deferred: a reclaimed folio is wiped
@@ -7443,7 +7443,7 @@ index 0000000000..4acf8318d6
 +					 * counters AND retires the scan-bitmap
 +					 * slot (so other CPUs stop re-finding
 +					 * this in-flight folio), but KEEPS the
-+					 * TRACKED byte so install_local's early-
++					 * TRACKED byte so marie_folio_install's early-
 +					 * out blocks any concurrent install from
 +					 * re-setting PG_lru while shrink_folio_-
 +					 * list reclaims it. The TRACKED byte is
@@ -8111,7 +8111,7 @@ index 0000000000..4acf8318d6
 + *   1. folio_try_get()        - reference held, folio cannot be freed.
 + *   2. folio_test_clear_lru() - PG_lru cleared atomically, gating
 + *                                external del paths.
-+ *   3. install_local TRACKED early-out (above)
++ *   3. marie_folio_install TRACKED early-out (above)
 + *
 + * memcg_bitmap is cleared here because the buddy free hook
 + * (marie_state_drop_pfn_at_free) runs without a folio reference and cannot
@@ -8768,7 +8768,7 @@ index 0000000000..585bea9c8e
 +/*
 + * clean_min_ratio: minimum file-pagecache reserve as percent of
 + * node_present_pages. Sysfs-tunable in core.c, read by reclaim.
-+ * Default 15 (le9uo recommendation for desktop).
++ * Default 10.
 + */
 +extern unsigned int marie_clean_min_ratio;
 +
@@ -8918,11 +8918,11 @@ index 0000000000..585bea9c8e
 + * counter updates on both source and destination (gen, type) planes.
 + *
 + * Single point of policy for any operation that needs to move a folio
-+ * between gens. Two callers in design.h:
-+ *   - walker tier saturate (section 7):
-+ *       marie_state_move_to_gen(pfn, head, 0)
-+ *   - shrink_folio_list residue putback (section 13):
-+ *       marie_state_move_to_gen(pfn, (head + 2) & 3, max(prev, w))
++ * between gens. Callers (all in state.c):
++ *   - MADV_COLD demote (marie_folio_demote):
++ *       marie_state_move_to_gen(pfn, oldest, 0)
++ *   - MADV_FREE (lru_marie_lazyfree): same (pfn, oldest, 0) form.
++ *     (The reclaim putback now uses marie_state_publish_at_gen.)
 + *
 + * The state-byte cmpxchg defeats races against del / another
 + * concurrent move. The bitmap / counter shuffle uses "new first, then
@@ -8940,9 +8940,9 @@ index 0000000000..585bea9c8e
 + * marie_state_drop_pfn - wipe every per-PFN tracking artifact
 + * (state byte, (type, gen, tier) L1 bit, occupancy counter, global
 + * L2 range counter with bulk L2 clear on 0) for @folio. Shared by the
-+ * normal evict path (marie_evict_locked) and the enable=0 drain path
-+ * (marie_drain_one_lruvec) so disable->enable cycles never leave
-+ * ghost per-PFN state behind. No-op when the byte is not TRACKED.
++ * normal evict path (marie_evict_locked) -- the runtime enable=0
++ * drain that used to share it was removed together with the boot-only
++ * static key. No-op when the byte is not TRACKED.
 + */
 +void marie_state_drop_pfn(struct folio *folio);
 +
@@ -9308,14 +9308,14 @@ index 0000000000..585bea9c8e
 + * ---------------------------------------------------------------------
 + *
 + * No promote-queue or per-CPU staging drain remains: every install /
-+ * evict / tier bump is synchronous (install_local / install_locked
-+ * publish per-PFN state inline, evict_locked wipes it inline,
-+ * marie_state_inc_tier handles saturation via marie_state_move_to_gen
-+ * directly).
++ * evict / tier bump is synchronous (marie_folio_install publishes
++ * per-PFN state inline, marie_evict_locked wipes it inline,
++ * marie_state_inc_tier handles saturation via an inline gen roll in
++ * __marie_state_inc_tier).
 + *
-+ * The remaining drain entry, marie_drain_one_lruvec (in core.c), is
-+ * only the enable/disable transition: it walks the per-(type, gen,
-+ * tier) bitmap and hands every TRACKED folio back to the legacy LRU.
++ * No enable/disable drain entry remains either: Marie is selected
++ * once at boot via the lru_marie= static key, before any folio is
++ * tracked, so there is nothing to hand back to the legacy LRU.
 + */
 +
 +/*
@@ -9528,7 +9528,7 @@ index 0000000000..8edb82807a
 +#define MARIE_PROGNAME	"Marie LRU"
 +#define MARIE_AUTHOR	"Masahito Suzuki"
 +
-+#define MARIE_VERSION	"0.7.7"
++#define MARIE_VERSION	"0.7.8"
 +
 +#endif /* _MM_LRU_MARIE_VERSION_H */
 diff --git a/mm/lru_marie/walker.c b/mm/lru_marie/walker.c
@@ -10595,7 +10595,7 @@ index 0000000000..5942d25151
 +
 +#endif /* _MM_LRU_MARIE_WALKER_COMPAT_H */
 diff --git a/mm/memcontrol-v1.c b/mm/memcontrol-v1.c
-index 6eed14bff7..4683579be1 100644
+index 433bba9dfe..a7923ef2fa 100644
 --- a/mm/memcontrol-v1.c
 +++ b/mm/memcontrol-v1.c
 @@ -11,6 +11,7 @@
@@ -10606,7 +10606,7 @@ index 6eed14bff7..4683579be1 100644
  
  #include "internal.h"
  #include "swap.h"
-@@ -1962,6 +1963,16 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
+@@ -2000,6 +2001,16 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
  	} else
  		WRITE_ONCE(vm_swappiness, val);
  
@@ -10624,7 +10624,7 @@ index 6eed14bff7..4683579be1 100644
  }
  
 diff --git a/mm/memcontrol.c b/mm/memcontrol.c
-index 61cf6af26f..ec13c53cd4 100644
+index 749c128b4f..12756d8863 100644
 --- a/mm/memcontrol.c
 +++ b/mm/memcontrol.c
 @@ -28,6 +28,7 @@
@@ -10635,7 +10635,7 @@ index 61cf6af26f..ec13c53cd4 100644
  #include <linux/cgroup.h>
  #include <linux/cpuset.h>
  #include <linux/sched/mm.h>
-@@ -4873,6 +4874,18 @@ static void uncharge_folio(struct folio *folio, struct uncharge_gather *ug)
+@@ -5178,6 +5179,26 @@ static void uncharge_folio(struct folio *folio, struct uncharge_gather *ug)
  			ug->nr_memory += nr_pages;
  		ug->pgpgout++;
  
@@ -10647,18 +10647,26 @@ index 61cf6af26f..ec13c53cd4 100644
 +		 * page-free hook that follows runs after memcg_data is zeroed
 +		 * and cannot resolve the lruvec. No-op for the common case (bit
 +		 * already retired by the normal evict path).
++		 *
++		 * 7.1: uncharge_folio is objcg-only (no memcg local). Resolve
++		 * the owning memcg from the pinned objcg under RCU --
++		 * obj_cgroup_memcg() requires it (objcg->memcg may be swapped to
++		 * the parent at reparent), and the read section keeps the
++		 * resolved memcg alive across the backstop's lruvec debit.
 +		 */
-+		lru_marie_uncharge_backstop(folio, memcg);
++		rcu_read_lock();
++		lru_marie_uncharge_backstop(folio, obj_cgroup_memcg(objcg));
++		rcu_read_unlock();
 +#endif
 +
  		WARN_ON_ONCE(folio_unqueue_deferred_split(folio));
- 		folio->memcg_data = 0;
  	}
+ 
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index 7712d887b6..7bc5c1d657 100644
+index f9f8e1af92..aae01205e5 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
-@@ -1412,6 +1412,9 @@ static void __meminit pgdat_init_internals(struct pglist_data *pgdat)
+@@ -1395,6 +1395,9 @@ static void __meminit pgdat_init_internals(struct pglist_data *pgdat)
  	pgdat_init_kcompactd(pgdat);
  
  	init_waitqueue_head(&pgdat->kswapd_wait);
@@ -10669,7 +10677,7 @@ index 7712d887b6..7bc5c1d657 100644
  
  	for (i = 0; i < NR_VMSCAN_THROTTLE; i++)
 diff --git a/mm/oom_kill.c b/mm/oom_kill.c
-index c145b0feec..c33bdac475 100644
+index 5f372f6e26..7020c0861f 100644
 --- a/mm/oom_kill.c
 +++ b/mm/oom_kill.c
 @@ -45,6 +45,10 @@
@@ -10703,7 +10711,7 @@ index c145b0feec..c33bdac475 100644
  
  /*
   * Serializes oom killer invocations (out_of_memory()) from all contexts to
-@@ -735,6 +752,15 @@ static const struct ctl_table vm_oom_kill_table[] = {
+@@ -720,6 +737,15 @@ static const struct ctl_table vm_oom_kill_table[] = {
  		.mode		= 0644,
  		.proc_handler	= proc_dointvec,
  	},
@@ -10719,12 +10727,11 @@ index c145b0feec..c33bdac475 100644
  };
  #endif
  
-@@ -1270,3 +1296,285 @@ SYSCALL_DEFINE2(process_mrelease, int, pidfd, unsigned int, flags)
+@@ -1255,3 +1281,282 @@ SYSCALL_DEFINE2(process_mrelease, int, pidfd, unsigned int, flags)
  	return -ENOSYS;
  #endif /* CONFIG_MMU */
  }
 +
-+#ifdef CONFIG_VM_EVENT_COUNTERS
 +/*
 + * Thrash-livelock watchdog.
 + *
@@ -10946,12 +10953,11 @@ index c145b0feec..c33bdac475 100644
 +		 * streaming page cache with gigabytes free is not mistaken for a
 +		 * livelock -- see thrash_wd_mem_pressured().
 +		 */
-+		unsigned long ev[NR_VM_EVENT_ITEMS];
 +		unsigned long refaults, steals, dr, ds;
 +
-+		all_vm_events(ev);
-+		steals = ev[PGSTEAL_KSWAPD] + ev[PGSTEAL_DIRECT] +
-+			 ev[PGSTEAL_KHUGEPAGED];
++		steals = global_node_page_state(PGSTEAL_KSWAPD) +
++			 global_node_page_state(PGSTEAL_DIRECT) +
++			 global_node_page_state(PGSTEAL_KHUGEPAGED);
 +		refaults = global_node_page_state(WORKINGSET_REFAULT_ANON) +
 +			   global_node_page_state(WORKINGSET_REFAULT_FILE);
 +
@@ -11004,12 +11010,11 @@ index c145b0feec..c33bdac475 100644
 +	return 0;
 +}
 +late_initcall(thrash_wd_init);
-+#endif /* CONFIG_VM_EVENT_COUNTERS */
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 6288c7e4b9..58678db525 100644
+index 23c7298d3b..31d110475b 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -17,6 +17,7 @@
+@@ -16,6 +16,7 @@
  
  #include <linux/stddef.h>
  #include <linux/mm.h>
@@ -11017,7 +11022,7 @@ index 6288c7e4b9..58678db525 100644
  #include <linux/highmem.h>
  #include <linux/interrupt.h>
  #include <linux/jiffies.h>
-@@ -1353,6 +1354,28 @@ __always_inline bool __free_pages_prepare(struct page *page,
+@@ -1314,6 +1315,28 @@ __always_inline bool __free_pages_prepare(struct page *page,
  	trace_mm_page_free(page, order);
  	kmsan_free_page(page, order);
  
@@ -11025,7 +11030,7 @@ index 6288c7e4b9..58678db525 100644
 +	/*
 +	 * Wipe Marie's per-PFN state at the buddy handoff. Marie's reclaim
 +	 * isolate path intentionally leaves marie_state[pfn]'s TRACKED bit
-+	 * set across shrink_folio_list (so install_local's TRACKED early-
++	 * set across shrink_folio_list (so marie_folio_install's TRACKED early-
 +	 * out keeps blocking concurrent installs on the in-flight folio);
 +	 * this hook is the canonical point at which that stale bit must
 +	 * disappear so the next allocation at this PFN starts clean. No-op
@@ -11046,7 +11051,7 @@ index 6288c7e4b9..58678db525 100644
  	if (memcg_kmem_online() && PageMemcgKmem(page))
  		__memcg_kmem_uncharge_page(page, order);
  
-@@ -4554,25 +4577,97 @@ bool gfp_pfmemalloc_allowed(gfp_t gfp_mask)
+@@ -4576,25 +4599,97 @@ bool gfp_pfmemalloc_allowed(gfp_t gfp_mask)
  static inline bool
  should_reclaim_retry(gfp_t gfp_mask, unsigned order,
  		     struct alloc_context *ac, int alloc_flags,
@@ -11147,7 +11152,7 @@ index 6288c7e4b9..58678db525 100644
  
  	/*
  	 * Keep reclaiming pages while there is a chance this will lead
-@@ -4699,6 +4794,20 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4718,6 +4813,20 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  		WARN_ON_ONCE(current->flags & PF_MEMALLOC);
  	}
  
@@ -11168,7 +11173,7 @@ index 6288c7e4b9..58678db525 100644
  restart:
  	compaction_retries = 0;
  	no_progress_loops = 0;
-@@ -4706,6 +4815,9 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4725,6 +4834,9 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  	compact_priority = DEF_COMPACT_PRIORITY;
  	cpuset_mems_cookie = read_mems_allowed_begin();
  	zonelist_iter_cookie = zonelist_iter_begin();
@@ -11177,9 +11182,9 @@ index 6288c7e4b9..58678db525 100644
 +			    global_node_page_state(WORKINGSET_REFAULT_FILE);
  
  	/*
- 	 * The fast path uses conservative alloc_flags to succeed only until
-@@ -4885,7 +4997,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
- 		goto nopage;
+ 	 * For costly allocations, try direct compaction first, as it's likely
+@@ -4881,7 +4993,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 		goto restart;
  
  	if (should_reclaim_retry(gfp_mask, order, ac, alloc_flags,
 -				 did_some_progress > 0, &no_progress_loops))
@@ -11188,7 +11193,7 @@ index 6288c7e4b9..58678db525 100644
  
  	/*
 diff --git a/mm/page_io.c b/mm/page_io.c
-index 3c342db77c..6e337a99ec 100644
+index 70cea9e24d..34930ac397 100644
 --- a/mm/page_io.c
 +++ b/mm/page_io.c
 @@ -25,8 +25,19 @@
@@ -11369,7 +11374,7 @@ index 3c342db77c..6e337a99ec 100644
  	if (zswap_store(folio)) {
  		count_mthp_stat(folio_order(folio), MTHP_STAT_ZSWPOUT);
  		goto out_unlock;
-@@ -288,6 +435,46 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
+@@ -292,6 +439,46 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
  	return ret;
  }
  
@@ -11417,7 +11422,7 @@ index 3c342db77c..6e337a99ec 100644
  {
  #ifdef CONFIG_TRANSPARENT_HUGEPAGE
 diff --git a/mm/rmap.c b/mm/rmap.c
-index 8f3c50bd11..818ee3881a 100644
+index 78b7fb5f36..0cfaf5bcce 100644
 --- a/mm/rmap.c
 +++ b/mm/rmap.c
 @@ -75,6 +75,7 @@
@@ -11428,20 +11433,20 @@ index 8f3c50bd11..818ee3881a 100644
  
  #include <asm/tlb.h>
  
-@@ -897,6 +898,11 @@ static bool folio_referenced_one(struct folio *folio,
- 		if (lru_gen_enabled() && pvmw.pte) {
- 			if (lru_gen_look_around(&pvmw))
+@@ -981,6 +982,11 @@ static bool folio_referenced_one(struct folio *folio,
+ 		if (lru_gen_enabled() && !lru_gen_switching() && pvmw.pte) {
+ 			if (lru_gen_look_around(&pvmw, nr))
  				referenced++;
 +#ifdef CONFIG_LRU_MARIE
 +		} else if (lru_marie_enabled() && pvmw.pte) {
-+			if (lru_marie_look_around(&pvmw, pvmw.nr_pages))
++			if (lru_marie_look_around(&pvmw, nr))
 +				referenced++;
 +#endif
  		} else if (pvmw.pte) {
- 			if (ptep_clear_flush_young_notify(vma, address,
- 						pvmw.pte))
+ 			if (clear_flush_young_ptes_notify(vma, address, pvmw.pte, nr))
+ 				referenced++;
 diff --git a/mm/swap.c b/mm/swap.c
-index 2260dcd277..7838fe0484 100644
+index 5cc44f0de9..5696ddebbd 100644
 --- a/mm/swap.c
 +++ b/mm/swap.c
 @@ -37,6 +37,7 @@
@@ -11584,7 +11589,7 @@ index 2260dcd277..7838fe0484 100644
  	folio_batch_add_and_move(folio, lru_move_tail);
  }
  
-@@ -300,6 +396,12 @@ void lru_note_cost_refault(struct folio *folio)
+@@ -304,6 +400,12 @@ void lru_note_cost_refault(struct folio *folio)
  				folio_nr_pages(folio), 0);
  }
  
@@ -11597,7 +11602,7 @@ index 2260dcd277..7838fe0484 100644
  static void lru_activate(struct lruvec *lruvec, struct folio *folio)
  {
  	long nr_pages = folio_nr_pages(folio);
-@@ -307,10 +409,24 @@ static void lru_activate(struct lruvec *lruvec, struct folio *folio)
+@@ -311,10 +413,24 @@ static void lru_activate(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_active(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11623,7 +11628,7 @@ index 2260dcd277..7838fe0484 100644
  	trace_mm_lru_activate(folio);
  
  	__count_vm_events(PGACTIVATE, nr_pages);
-@@ -332,6 +448,13 @@ void folio_activate(struct folio *folio)
+@@ -336,6 +452,13 @@ void folio_activate(struct folio *folio)
  	    !folio_test_lru(folio))
  		return;
  
@@ -11637,7 +11642,7 @@ index 2260dcd277..7838fe0484 100644
  	folio_batch_add_and_move(folio, lru_activate);
  }
  
-@@ -347,6 +470,15 @@ void folio_activate(struct folio *folio)
+@@ -351,6 +474,15 @@ void folio_activate(struct folio *folio)
  	if (!folio_test_clear_lru(folio))
  		return;
  
@@ -11652,8 +11657,8 @@ index 2260dcd277..7838fe0484 100644
 +
  	lruvec = folio_lruvec_lock_irq(folio);
  	lru_activate(lruvec, folio);
- 	unlock_page_lruvec_irq(lruvec);
-@@ -460,6 +592,32 @@ void folio_mark_accessed(struct folio *folio)
+ 	lruvec_unlock_irq(lruvec);
+@@ -466,6 +598,32 @@ void folio_mark_accessed(struct folio *folio)
  		lru_gen_inc_refs(folio);
  		return;
  	}
@@ -11686,7 +11691,7 @@ index 2260dcd277..7838fe0484 100644
  
  	if (!folio_test_referenced(folio)) {
  		folio_set_referenced(folio);
-@@ -504,9 +662,24 @@ void folio_add_lru(struct folio *folio)
+@@ -510,9 +668,24 @@ void folio_add_lru(struct folio *folio)
  	VM_BUG_ON_FOLIO(folio_test_lru(folio), folio);
  
  	/* see the comment in lru_gen_folio_seq() */
@@ -11711,7 +11716,7 @@ index 2260dcd277..7838fe0484 100644
  
  	folio_batch_add_and_move(folio, lru_add);
  }
-@@ -563,6 +736,11 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
+@@ -569,6 +742,11 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
  	if (folio_mapped(folio))
  		return;
  
@@ -11723,7 +11728,7 @@ index 2260dcd277..7838fe0484 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	folio_clear_referenced(folio);
-@@ -574,14 +752,24 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
+@@ -580,14 +758,24 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
  		 * race window is _really_ small and  it's not a critical
  		 * problem.
  		 */
@@ -11750,7 +11755,7 @@ index 2260dcd277..7838fe0484 100644
  		__count_vm_events(PGROTATED, nr_pages);
  	}
  
-@@ -599,10 +787,20 @@ static void lru_deactivate(struct lruvec *lruvec, struct folio *folio)
+@@ -605,10 +793,20 @@ static void lru_deactivate(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_unevictable(folio) || !(folio_test_active(folio) || lru_gen_enabled()))
  		return;
  
@@ -11772,7 +11777,7 @@ index 2260dcd277..7838fe0484 100644
  
  	__count_vm_events(PGDEACTIVATE, nr_pages);
  	count_memcg_events(lruvec_memcg(lruvec), PGDEACTIVATE, nr_pages);
-@@ -616,6 +814,11 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
+@@ -622,6 +820,11 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
  	    folio_test_swapcache(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11784,7 +11789,7 @@ index 2260dcd277..7838fe0484 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	if (lru_gen_enabled())
-@@ -628,7 +831,12 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
+@@ -634,7 +837,12 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
  	 * anonymous folios
  	 */
  	folio_clear_swapbacked(folio);
@@ -11798,7 +11803,7 @@ index 2260dcd277..7838fe0484 100644
  
  	__count_vm_events(PGLAZYFREE, nr_pages);
  	count_memcg_events(lruvec_memcg(lruvec), PGLAZYFREE, nr_pages);
-@@ -692,6 +900,13 @@ void deactivate_file_folio(struct folio *folio)
+@@ -698,6 +906,13 @@ void deactivate_file_folio(struct folio *folio)
  	if (lru_gen_enabled() && lru_gen_clear_refs(folio))
  		return;
  
@@ -11812,7 +11817,7 @@ index 2260dcd277..7838fe0484 100644
  	folio_batch_add_and_move(folio, lru_deactivate_file);
  }
  
-@@ -711,6 +926,13 @@ void folio_deactivate(struct folio *folio)
+@@ -717,6 +932,13 @@ void folio_deactivate(struct folio *folio)
  	if (lru_gen_enabled() ? lru_gen_clear_refs(folio) : !folio_test_active(folio))
  		return;
  
@@ -11826,7 +11831,7 @@ index 2260dcd277..7838fe0484 100644
  	folio_batch_add_and_move(folio, lru_deactivate);
  }
  
-@@ -728,6 +950,14 @@ void folio_mark_lazyfree(struct folio *folio)
+@@ -734,6 +956,14 @@ void folio_mark_lazyfree(struct folio *folio)
  	    folio_test_swapcache(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11842,10 +11847,10 @@ index 2260dcd277..7838fe0484 100644
  }
  
 diff --git a/mm/swap.h b/mm/swap.h
-index c6bdc5d215..95edddea04 100644
+index a77016f242..fc816e14de 100644
 --- a/mm/swap.h
 +++ b/mm/swap.h
-@@ -196,6 +196,10 @@ static inline void swap_read_unplug(struct swap_iocb *plug)
+@@ -227,6 +227,10 @@ static inline void swap_read_unplug(struct swap_iocb *plug)
  void swap_write_unplug(struct swap_iocb *sio);
  int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug);
  void __swap_writepage(struct folio *folio, struct swap_iocb **swap_plug);
@@ -11857,7 +11862,7 @@ index c6bdc5d215..95edddea04 100644
  /* linux/mm/swap_state.c */
  extern struct address_space swap_space __read_mostly;
 diff --git a/mm/vmscan.c b/mm/vmscan.c
-index 95b1179a14..de1437b29b 100644
+index bd1b1aa125..975007fa9f 100644
 --- a/mm/vmscan.c
 +++ b/mm/vmscan.c
 @@ -39,6 +39,7 @@
@@ -11868,7 +11873,7 @@ index 95b1179a14..de1437b29b 100644
  #include <linux/migrate.h>
  #include <linux/delayacct.h>
  #include <linux/sysctl.h>
-@@ -182,6 +183,34 @@ struct scan_control {
+@@ -181,6 +182,34 @@ struct scan_control {
  	struct reclaim_state reclaim_state;
  };
  
@@ -11903,14 +11908,14 @@ index 95b1179a14..de1437b29b 100644
  #ifdef ARCH_HAS_PREFETCHW
  #define prefetchw_prev_lru_folio(_folio, _base, _field)			\
  	do {								\
-@@ -479,6 +508,45 @@ static int reclaimer_offset(struct scan_control *sc)
+@@ -458,6 +487,44 @@ static int reclaimer_offset(struct scan_control *sc)
  	return PGSTEAL_DIRECT - PGSTEAL_KSWAPD;
  }
  
 +#ifdef CONFIG_LRU_MARIE
 +/*
 + * Wrapper used by mm/lru_marie, which sees @sc but not the static
-+ * reclaimer_offset() above. On 6.18+ reclaimer_offset() takes @sc, so
++ * reclaimer_offset() above. On 6.18+/7.x reclaimer_offset() takes @sc, so
 + * forward it.
 + */
 +int vmscan_reclaimer_offset(struct scan_control *sc)
@@ -11945,11 +11950,10 @@ index 95b1179a14..de1437b29b 100644
 +	return can_reclaim_anon_pages(memcg, nid, sc);
 +}
 +#endif
-+
- static inline int is_page_cache_freeable(struct folio *folio)
- {
- 	/*
-@@ -922,10 +990,7 @@ static enum folio_references folio_check_references(struct folio *folio,
+ /*
+  * We detected a synchronous write error writing a folio out.  Probably
+  * -ENOSPC.  We need to propagate that into the address_space for a subsequent
+@@ -877,10 +944,7 @@ static enum folio_references folio_check_references(struct folio *folio,
  		return FOLIOREF_ACTIVATE;
  
  	/*
@@ -11961,7 +11965,7 @@ index 95b1179a14..de1437b29b 100644
  	 */
  	if (referenced_ptes == -1)
  		return FOLIOREF_KEEP;
-@@ -939,6 +1004,30 @@ static enum folio_references folio_check_references(struct folio *folio,
+@@ -894,6 +958,30 @@ static enum folio_references folio_check_references(struct folio *folio,
  
  	referenced_folio = folio_test_clear_referenced(folio);
  
@@ -11992,7 +11996,7 @@ index 95b1179a14..de1437b29b 100644
  	if (referenced_ptes) {
  		/*
  		 * All mapped folios start out with page table
-@@ -1104,9 +1193,13 @@ static bool may_enter_fs(struct folio *folio, gfp_t gfp_mask)
+@@ -1053,9 +1141,13 @@ static bool may_enter_fs(struct folio *folio, gfp_t gfp_mask)
  }
  
  /*
@@ -12008,10 +12012,10 @@ index 95b1179a14..de1437b29b 100644
  		struct pglist_data *pgdat, struct scan_control *sc,
  		struct reclaim_stat *stat, bool ignore_references,
  		struct mem_cgroup *memcg)
-@@ -1981,7 +2074,29 @@ static unsigned int move_folios_to_lru(struct lruvec *lruvec,
- 		 * inhibits memcg migration).
- 		 */
- 		VM_BUG_ON_FOLIO(!folio_matches_lruvec(folio, lruvec), folio);
+@@ -1916,7 +2008,29 @@ static unsigned int move_folios_to_lru(struct list_head *list)
+ 			continue;
+ 		}
+ 
 -		lruvec_add_folio(lruvec, folio);
 +#ifdef CONFIG_LRU_MARIE
 +		/*
@@ -12039,7 +12043,7 @@ index 95b1179a14..de1437b29b 100644
  		nr_pages = folio_nr_pages(folio);
  		nr_moved += nr_pages;
  		if (folio_test_active(folio))
-@@ -5201,6 +5316,55 @@ static bool drain_evictable(struct lruvec *lruvec)
+@@ -5307,6 +5421,55 @@ static bool drain_evictable(struct lruvec *lruvec)
  	return true;
  }
  
@@ -12095,7 +12099,7 @@ index 95b1179a14..de1437b29b 100644
  static void lru_gen_change_state(bool enabled)
  {
  	static DEFINE_MUTEX(state_mutex);
-@@ -5723,7 +5887,15 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
+@@ -5827,7 +5990,15 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
  	struct lru_gen_mm_state *mm_state = get_mm_state(lruvec);
  
  	lrugen->max_seq = MIN_NR_GENS + 1;
@@ -12112,7 +12116,7 @@ index 95b1179a14..de1437b29b 100644
  
  	for (i = 0; i <= MIN_NR_GENS + 1; i++)
  		lrugen->timestamps[i] = jiffies;
-@@ -5823,7 +5995,23 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
+@@ -5927,7 +6098,23 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
  	unsigned long nr_to_reclaim = sc->nr_to_reclaim;
  	bool proportional_reclaim;
  	struct blk_plug plug;
@@ -12125,18 +12129,18 @@ index 95b1179a14..de1437b29b 100644
 +		marie_drain_mask = lru_marie_shrink_lruvec(lruvec, sc);
 +		/*
 +		 * Fall through to the legacy reclaim path below to drain orphan
-+		 * folios (failed Marie install, drain/reparent handoffs) that
-+		 * landed on lruvec->lists; MGLRU is bypassed under Marie. The
-+		 * drain is constrained by marie_drain_mask below so it touches
-+		 * only the type(s) Marie scanned. Common case: the lists are
-+		 * empty and this is a cheap no-op.
++		 * folios (failed Marie install) that landed on lruvec->lists;
++		 * MGLRU is bypassed under Marie. The drain is constrained by
++		 * marie_drain_mask below so it touches only the type(s) Marie
++		 * scanned. Common case: the lists are empty and this is a cheap
++		 * no-op.
 +		 */
 +	} else
 +#endif
- 	if (lru_gen_enabled() && !root_reclaim(sc)) {
+ 	if ((lru_gen_enabled() || lru_gen_switching()) && !root_reclaim(sc)) {
  		lru_gen_shrink_lruvec(lruvec, sc);
- 		return;
-@@ -5831,6 +6019,29 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
+ 
+@@ -5938,6 +6125,29 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
  
  	get_scan_count(lruvec, sc, nr);
  
@@ -12166,10 +12170,11 @@ index 95b1179a14..de1437b29b 100644
  	/* Record the original scan target for proportional adjustments later */
  	memcpy(targets, nr, sizeof(nr));
  
-@@ -6086,11 +6297,26 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
+@@ -6193,14 +6403,32 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
  	struct lruvec *target_lruvec;
  	bool reclaimable = false;
  
+-	if ((lru_gen_enabled() || lru_gen_switching()) && root_reclaim(sc)) {
 +#ifdef CONFIG_LRU_MARIE
 +	/*
 +	 * MGLRU's root-reclaim shortcut bypasses shrink_node_memcgs entirely,
@@ -12179,21 +12184,27 @@ index 95b1179a14..de1437b29b 100644
 +	 * at all.  Gate the shortcut on !lru_marie_enabled() so kswapd takes the
 +	 * standard shrink_node_memcgs path under Marie.
 +	 */
-+	if (!lru_marie_enabled() && lru_gen_enabled() && root_reclaim(sc)) {
-+		lru_gen_shrink_node(pgdat, sc);
-+		return;
-+	}
-+#else
- 	if (lru_gen_enabled() && root_reclaim(sc)) {
++	if (!lru_marie_enabled() &&
++	    (lru_gen_enabled() || lru_gen_switching()) && root_reclaim(sc)) {
  		memset(&sc->nr, 0, sizeof(sc->nr));
  		lru_gen_shrink_node(pgdat, sc);
- 		return;
+ 
+ 		if (!lru_gen_switching())
+ 			return;
++	}
++#else
++	if ((lru_gen_enabled() || lru_gen_switching()) && root_reclaim(sc)) {
++		memset(&sc->nr, 0, sizeof(sc->nr));
++		lru_gen_shrink_node(pgdat, sc);
+ 
++		if (!lru_gen_switching())
++			return;
  	}
 +#endif
  
  	target_lruvec = mem_cgroup_lruvec(sc->target_mem_cgroup, pgdat);
  
-@@ -6364,6 +6590,17 @@ static void snapshot_refaults(struct mem_cgroup *target_memcg, pg_data_t *pgdat)
+@@ -6469,6 +6697,17 @@ static void snapshot_refaults(struct mem_cgroup *target_memcg, pg_data_t *pgdat)
  	struct lruvec *target_lruvec;
  	unsigned long refaults;
  
@@ -12208,10 +12219,10 @@ index 95b1179a14..de1437b29b 100644
 +		return;
 +#endif
 +
- 	if (lru_gen_enabled())
+ 	if (lru_gen_enabled() && !lru_gen_switching())
  		return;
  
-@@ -6760,6 +6997,21 @@ static void kswapd_age_node(struct pglist_data *pgdat, struct scan_control *sc)
+@@ -6859,6 +7098,21 @@ static void kswapd_age_node(struct pglist_data *pgdat, struct scan_control *sc)
  	struct mem_cgroup *memcg;
  	struct lruvec *lruvec;
  
@@ -12230,10 +12241,10 @@ index 95b1179a14..de1437b29b 100644
 +	}
 +#endif
 +
- 	if (lru_gen_enabled()) {
+ 	if (lru_gen_enabled() || lru_gen_switching()) {
  		lru_gen_age_node(pgdat, sc);
- 		return;
-@@ -7504,6 +7756,9 @@ unsigned long shrink_all_memory(unsigned long nr_to_reclaim)
+ 
+@@ -7632,6 +7886,9 @@ unsigned long shrink_all_memory(unsigned long nr_to_reclaim)
  void __meminit kswapd_run(int nid)
  {
  	pg_data_t *pgdat = NODE_DATA(nid);
@@ -12243,7 +12254,7 @@ index 95b1179a14..de1437b29b 100644
  
  	pgdat_kswapd_lock(pgdat);
  	if (!pgdat->kswapd) {
-@@ -7517,7 +7772,32 @@ void __meminit kswapd_run(int nid)
+@@ -7645,7 +7902,32 @@ void __meminit kswapd_run(int nid)
  		} else {
  			wake_up_process(pgdat->kswapd);
  		}
@@ -12276,7 +12287,7 @@ index 95b1179a14..de1437b29b 100644
  	pgdat_kswapd_unlock(pgdat);
  }
  
-@@ -7536,16 +7816,52 @@ void __meminit kswapd_stop(int nid)
+@@ -7664,16 +7946,52 @@ void __meminit kswapd_stop(int nid)
  		kthread_stop(kswapd);
  		pgdat->kswapd = NULL;
  	}

--- a/patches/testing/0001-linux7.2-rc1-lru_marie-0.7.8.patch
+++ b/patches/testing/0001-linux7.2-rc1-lru_marie-0.7.8.patch
@@ -1,7 +1,7 @@
-From 781c580b033d8d14121be6739173bee70d734ff9 Mon Sep 17 00:00:00 2001
+From 7c2f3a239e0c6e830c8092d1a23e7d70f30accf7 Mon Sep 17 00:00:00 2001
 From: Masahito S <firelzrd@gmail.com>
 Date: Mon, 13 Jul 2026 01:28:36 +0900
-Subject: [PATCH] linux7.1-rc5-lru_marie-0.7.7
+Subject: [PATCH] linux7.2-rc1-lru_marie-0.7.8
 
 ---
  include/linux/lru_marie.h      |  493 ++++++
@@ -30,7 +30,7 @@ Subject: [PATCH] linux7.1-rc5-lru_marie-0.7.7
  mm/lru_marie/simd_x86_avx2.S   |  152 ++
  mm/lru_marie/simd_x86_avx512.S |  199 +++
  mm/lru_marie/simd_x86_sse2.S   |  158 ++
- mm/lru_marie/state.c           | 3014 ++++++++++++++++++++++++++++++++
+ mm/lru_marie/state.c           | 3013 ++++++++++++++++++++++++++++++++
  mm/lru_marie/state.h           |  987 +++++++++++
  mm/lru_marie/state_compat.h    |   94 +
  mm/lru_marie/version.h         |   22 +
@@ -43,10 +43,10 @@ Subject: [PATCH] linux7.1-rc5-lru_marie-0.7.7
  mm/page_alloc.c                |  120 +-
  mm/page_io.c                   |  187 ++
  mm/rmap.c                      |    6 +
- mm/swap.c                      |  248 ++-
+ mm/swap.c                      |  258 ++-
  mm/swap.h                      |    4 +
  mm/vmscan.c                    |  336 +++-
- 42 files changed, 11374 insertions(+), 28 deletions(-)
+ 42 files changed, 11383 insertions(+), 28 deletions(-)
  create mode 100644 include/linux/lru_marie.h
  create mode 100644 mm/lru_marie/Makefile
  create mode 100644 mm/lru_marie/account.h
@@ -246,7 +246,7 @@ index 0000000000..fc30269822
 + * to enter the buddy allocator. When marie_state[pfn] still carries
 + * TRACKED -- which happens whenever the reclaim isolate path
 + * (marie_evict_counters_only) decremented counters but intentionally
-+ * preserved the state byte so install_local's TRACKED early-out kept
++ * preserved the state byte so marie_folio_install's TRACKED early-out kept
 + * blocking concurrent installs during shrink_folio_list -- this wipes
 + * the byte, the global (type, gen, tier) bitmap bit, and the
 + * gen_occupied slot in one lock-free pass.
@@ -571,10 +571,10 @@ index 0000000000..fc30269822
 +
 +#endif /* _LINUX_LRU_MARIE_H */
 diff --git a/include/linux/memcontrol.h b/include/linux/memcontrol.h
-index dc3fa68775..bde5bd78ff 100644
+index e1f46a0016..dedb751ed4 100644
 --- a/include/linux/memcontrol.h
 +++ b/include/linux/memcontrol.h
-@@ -880,14 +880,38 @@ static inline bool mem_cgroup_online(struct mem_cgroup *memcg)
+@@ -877,14 +877,38 @@ static inline bool mem_cgroup_online(struct mem_cgroup *memcg)
  void mem_cgroup_update_lru_size(struct lruvec *lruvec, enum lru_list lru,
  		int zid, long nr_pages);
  
@@ -615,7 +615,7 @@ index dc3fa68775..bde5bd78ff 100644
  
  void __mem_cgroup_handle_over_high(gfp_t gfp_mask);
 diff --git a/include/linux/mm_inline.h b/include/linux/mm_inline.h
-index a171070e15..4779a3b6b9 100644
+index a8430a7ae0..da6659f066 100644
 --- a/include/linux/mm_inline.h
 +++ b/include/linux/mm_inline.h
 @@ -5,6 +5,7 @@
@@ -801,7 +801,7 @@ index a171070e15..4779a3b6b9 100644
  		return;
  
 diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
-index 9adb2ad21d..3dd56a3add 100644
+index ca27121871..9430caa4a0 100644
 --- a/include/linux/mmzone.h
 +++ b/include/linux/mmzone.h
 @@ -24,6 +24,7 @@
@@ -812,7 +812,7 @@ index 9adb2ad21d..3dd56a3add 100644
  #include <asm/page.h>
  
  /* Free memory management - zoned buddy allocator.  */
-@@ -1529,6 +1530,20 @@ typedef struct pglist_data {
+@@ -1522,6 +1523,20 @@ typedef struct pglist_data {
  
  	atomic_t kswapd_failures;	/* Number of 'reclaimed == 0' runs */
  
@@ -834,7 +834,7 @@ index 9adb2ad21d..3dd56a3add 100644
  	int kcompactd_max_order;
  	enum zone_type kcompactd_highest_zoneidx;
 diff --git a/include/linux/swap.h b/include/linux/swap.h
-index 7a09df6977..cb9d9acecb 100644
+index 8f0f68e245..66eaf4f962 100644
 --- a/include/linux/swap.h
 +++ b/include/linux/swap.h
 @@ -421,6 +421,24 @@ extern atomic_long_t nr_swap_pages;
@@ -863,10 +863,10 @@ index 7a09df6977..cb9d9acecb 100644
  static inline bool vm_swap_full(void)
  {
 diff --git a/mm/Kconfig b/mm/Kconfig
-index e8bf1e9e6a..9de11ccbdc 100644
+index 9e0ca48249..62381669b0 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
-@@ -1396,6 +1396,60 @@ config LRU_GEN_WALKS_MMU
+@@ -1435,6 +1435,60 @@ config LRU_GEN_WALKS_MMU
  	depends on LRU_GEN && ARCH_HAS_HW_PTE_YOUNG
  # }
  
@@ -928,7 +928,7 @@ index e8bf1e9e6a..9de11ccbdc 100644
         def_bool n
  
 diff --git a/mm/Makefile b/mm/Makefile
-index 8ad2ab0824..1f8385ecee 100644
+index eff9f9e7e0..b82d9b6ac3 100644
 --- a/mm/Makefile
 +++ b/mm/Makefile
 @@ -76,6 +76,7 @@ ifdef CONFIG_MMU
@@ -940,7 +940,7 @@ index 8ad2ab0824..1f8385ecee 100644
  obj-$(CONFIG_HAS_DMA)	+= dmapool.o
  obj-$(CONFIG_HUGETLBFS)	+= hugetlb.o hugetlb_sysfs.o hugetlb_sysctl.o
 diff --git a/mm/compaction.c b/mm/compaction.c
-index 3648ce22c8..3f0f769c1d 100644
+index b776f35ad0..35e49b17dc 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -24,6 +24,7 @@
@@ -951,7 +951,7 @@ index 3648ce22c8..3f0f769c1d 100644
  #include "internal.h"
  
  #ifdef CONFIG_COMPACTION
-@@ -3092,6 +3093,23 @@ static void kcompactd_do_work(pg_data_t *pgdat)
+@@ -3097,6 +3098,23 @@ static void kcompactd_do_work(pg_data_t *pgdat)
  							cc.highest_zoneidx);
  	count_compact_event(KCOMPACTD_WAKE);
  
@@ -975,7 +975,7 @@ index 3648ce22c8..3f0f769c1d 100644
  	for (zoneid = 0; zoneid <= cc.highest_zoneidx; zoneid++) {
  		int status;
  
-@@ -3228,7 +3246,19 @@ static int kcompactd(void *p)
+@@ -3233,7 +3251,19 @@ static int kcompactd(void *p)
  			unsigned int prev_score, score;
  
  			prev_score = fragmentation_score_node(pgdat);
@@ -997,7 +997,7 @@ index 3648ce22c8..3f0f769c1d 100644
  			/*
  			 * Defer proactive compaction if the fragmentation
 diff --git a/mm/huge_memory.c b/mm/huge_memory.c
-index 970e077019..8ba88176e3 100644
+index 2bccb0a53a..31ffbe3610 100644
 --- a/mm/huge_memory.c
 +++ b/mm/huge_memory.c
 @@ -6,6 +6,7 @@
@@ -1008,7 +1008,7 @@ index 970e077019..8ba88176e3 100644
  #include <linux/sched.h>
  #include <linux/sched/mm.h>
  #include <linux/sched/numa_balancing.h>
-@@ -3558,14 +3559,48 @@ static void lru_add_split_folio(struct folio *folio, struct folio *new_folio,
+@@ -3500,14 +3501,48 @@ static void lru_add_split_folio(struct folio *folio, struct folio *new_folio,
  		/* page reclaim is reclaiming a huge page */
  		VM_WARN_ON(folio_test_lru(folio));
  		folio_get(new_folio);
@@ -1060,10 +1060,10 @@ index 970e077019..8ba88176e3 100644
  	}
  }
 diff --git a/mm/internal.h b/mm/internal.h
-index 5a2ddcf68e..4f640c01f3 100644
+index 181e79f1d6..9b88fa9da3 100644
 --- a/mm/internal.h
 +++ b/mm/internal.h
-@@ -625,12 +625,55 @@ extern unsigned long highest_memmap_pfn;
+@@ -616,12 +616,55 @@ extern unsigned long highest_memmap_pfn;
   */
  #define MAX_RECLAIM_RETRIES 16
  
@@ -1119,7 +1119,7 @@ index 5a2ddcf68e..4f640c01f3 100644
  int user_proactive_reclaim(char *buf,
  			   struct mem_cgroup *memcg, pg_data_t *pgdat);
  
-@@ -693,6 +736,30 @@ struct alloc_context {
+@@ -684,6 +727,30 @@ struct alloc_context {
  	 */
  	enum zone_type highest_zoneidx;
  	bool spread_dirty_pages;
@@ -1664,7 +1664,7 @@ index 0000000000..e2feeee275
 + *     no per-(lru, zone) shadow counter to bounce
 + *   - per-pgdat walker driven from kswapd, with rmap-fed bloom
 + *     feedback so PMD scans concentrate on hot regions
-+ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 4)
++ *   - single global cycling per-type gen clock (MARIE_PFN_NR_GENS = 8)
 + *     encoded in the per-PFN byte, advanced by global install cadence
 + *     (marie_folio_install counts installs onto the head gen and
 + *     advances at marie_gen_growth_live[type])
@@ -1870,14 +1870,14 @@ index 0000000000..e2feeee275
 + *   - lru_marie_add_folio always lands on the current head gen
 + *     (atomic_read(&marie_head_gen[type])).
 + *   - marie_state_isolate_scan_l2lock always pulls from the oldest
-+ *     occupied gen (marie_find_oldest_occupied).
++ *     occupied gen (marie_find_oldest_occupied_mlv).
 + *   - shrink_folio_list classifies each isolated folio:
 + *       FOLIOREF_RECLAIM  → freed (this folio truly was cold)
 + *       FOLIOREF_KEEP     → returned in folio_list, putback re-routes
 + *       FOLIOREF_ACTIVATE → ditto, with PG_active set
-+ *     putback re-installs the survivor at (oldest+1)&3 with
++ *     putback re-installs the survivor at (oldest+1)&7 with
 + *     target_tier = max(prev_tier, w_tier) via
-+ *     marie_install_at_gen.
++ *     marie_state_publish_at_gen.
 + *   - head_gen advances per type via marie_try_advance_head_mlv (the
 + *     _mlv suffix is historical -- the clock is a single global one per
 + *     type), fired by global install cadence alone (marie_folio_install
@@ -5396,7 +5396,7 @@ new file mode 100644
 index 0000000000..4acf8318d6
 --- /dev/null
 +++ b/mm/lru_marie/state.c
-@@ -0,0 +1,3014 @@
+@@ -0,0 +1,3013 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Marie per-PFN state array — allocation, init, and global counters.
@@ -6236,7 +6236,7 @@ index 0000000000..4acf8318d6
 + * between marie_evict_counters_only (counters -1, TRACKED preserved) and
 + * the next allocation at the same PFN: the moment the page is destined
 + * for buddy, we wipe Marie's per-PFN bookkeeping so a subsequent
-+ * install_local starts from a clean state byte.
++ * marie_folio_install starts from a clean state byte.
 + *
 + * Counters are NOT touched here -- they were either already balanced
 + * by marie_evict_locked (the normal Marie del path) or pre-decremented
@@ -6459,9 +6459,9 @@ index 0000000000..4acf8318d6
 + * encodes (target_gen, target_tier).
 + *
 + * Called from:
-+ *   marie_state_inc_tier saturate path (target_gen=head, target_tier=0)
-+ *   shrink_lruvec residue putback (target_gen=(head+2)&3,
-+ *                                  target_tier=max(prev, w_tier))
++ *   marie_folio_demote / lru_marie_lazyfree (MADV_COLD / MADV_FREE),
++ *   both as (target_gen=oldest, target_tier=0). The tier-saturate
++ *   roll is open-coded inline in __marie_state_inc_tier instead.
 + */
 +void marie_state_move_to_gen(unsigned long pfn,
 +			     u8 target_gen, u8 target_tier)
@@ -6792,7 +6792,7 @@ index 0000000000..4acf8318d6
 +			    unsigned long nr_reclaimed,
 +			    u8 swappiness)
 +{
-+	s64 cur, delta;
++	s64 delta;
 +
 +	/*
 +	 * Special values bypass the controller. The pick path does not
@@ -6818,8 +6818,7 @@ index 0000000000..4acf8318d6
 +	else
 +		delta = +(s64)nr_reclaimed * (s64)swappiness;
 +
-+	cur = atomic64_read(&marie_swap_bias);
-+	atomic64_set(&marie_swap_bias, cur + delta);
++	atomic64_add(delta, &marie_swap_bias);
 +}
 +
 +/*
@@ -6994,7 +6993,7 @@ index 0000000000..4acf8318d6
 + * reclaim-driven trigger, fired ONLY on true exhaustion (the retired
 + * unconditional "occupied < 2 at entry" form thrashed the ring). Without
 + * demand-pull a workload that stops installing a type strands its
-+ * head-gen pages, since marie_find_oldest_occupied skips head (the
++ * head-gen pages, since marie_find_oldest_occupied_mlv skips head (the
 + * install destination).
 + *
 + * Per (type, tier) the scan walks the per-(gen, type) bitmap, claims
@@ -7002,7 +7001,7 @@ index 0000000000..4acf8318d6
 + * marie_evict_counters_only: counters decremented and the scan-bitmap
 + * slot + gen_occupied retired at isolate (so other CPUs stop re-finding
 + * the in-flight folio), but the per-PFN TRACKED byte is KEPT so
-+ * install_local's early-out blocks a concurrent install from re-setting
++ * marie_folio_install's early-out blocks a concurrent install from re-setting
 + * PG_lru while shrink_folio_list reclaims it.
 + *
 + * Teardown of the TRACKED byte is deferred: a reclaimed folio is wiped
@@ -7444,7 +7443,7 @@ index 0000000000..4acf8318d6
 +					 * counters AND retires the scan-bitmap
 +					 * slot (so other CPUs stop re-finding
 +					 * this in-flight folio), but KEEPS the
-+					 * TRACKED byte so install_local's early-
++					 * TRACKED byte so marie_folio_install's early-
 +					 * out blocks any concurrent install from
 +					 * re-setting PG_lru while shrink_folio_-
 +					 * list reclaims it. The TRACKED byte is
@@ -8112,7 +8111,7 @@ index 0000000000..4acf8318d6
 + *   1. folio_try_get()        - reference held, folio cannot be freed.
 + *   2. folio_test_clear_lru() - PG_lru cleared atomically, gating
 + *                                external del paths.
-+ *   3. install_local TRACKED early-out (above)
++ *   3. marie_folio_install TRACKED early-out (above)
 + *
 + * memcg_bitmap is cleared here because the buddy free hook
 + * (marie_state_drop_pfn_at_free) runs without a folio reference and cannot
@@ -8769,7 +8768,7 @@ index 0000000000..585bea9c8e
 +/*
 + * clean_min_ratio: minimum file-pagecache reserve as percent of
 + * node_present_pages. Sysfs-tunable in core.c, read by reclaim.
-+ * Default 15 (le9uo recommendation for desktop).
++ * Default 10.
 + */
 +extern unsigned int marie_clean_min_ratio;
 +
@@ -8919,11 +8918,11 @@ index 0000000000..585bea9c8e
 + * counter updates on both source and destination (gen, type) planes.
 + *
 + * Single point of policy for any operation that needs to move a folio
-+ * between gens. Two callers in design.h:
-+ *   - walker tier saturate (section 7):
-+ *       marie_state_move_to_gen(pfn, head, 0)
-+ *   - shrink_folio_list residue putback (section 13):
-+ *       marie_state_move_to_gen(pfn, (head + 2) & 3, max(prev, w))
++ * between gens. Callers (all in state.c):
++ *   - MADV_COLD demote (marie_folio_demote):
++ *       marie_state_move_to_gen(pfn, oldest, 0)
++ *   - MADV_FREE (lru_marie_lazyfree): same (pfn, oldest, 0) form.
++ *     (The reclaim putback now uses marie_state_publish_at_gen.)
 + *
 + * The state-byte cmpxchg defeats races against del / another
 + * concurrent move. The bitmap / counter shuffle uses "new first, then
@@ -8941,9 +8940,9 @@ index 0000000000..585bea9c8e
 + * marie_state_drop_pfn - wipe every per-PFN tracking artifact
 + * (state byte, (type, gen, tier) L1 bit, occupancy counter, global
 + * L2 range counter with bulk L2 clear on 0) for @folio. Shared by the
-+ * normal evict path (marie_evict_locked) and the enable=0 drain path
-+ * (marie_drain_one_lruvec) so disable->enable cycles never leave
-+ * ghost per-PFN state behind. No-op when the byte is not TRACKED.
++ * normal evict path (marie_evict_locked) -- the runtime enable=0
++ * drain that used to share it was removed together with the boot-only
++ * static key. No-op when the byte is not TRACKED.
 + */
 +void marie_state_drop_pfn(struct folio *folio);
 +
@@ -9309,14 +9308,14 @@ index 0000000000..585bea9c8e
 + * ---------------------------------------------------------------------
 + *
 + * No promote-queue or per-CPU staging drain remains: every install /
-+ * evict / tier bump is synchronous (install_local / install_locked
-+ * publish per-PFN state inline, evict_locked wipes it inline,
-+ * marie_state_inc_tier handles saturation via marie_state_move_to_gen
-+ * directly).
++ * evict / tier bump is synchronous (marie_folio_install publishes
++ * per-PFN state inline, marie_evict_locked wipes it inline,
++ * marie_state_inc_tier handles saturation via an inline gen roll in
++ * __marie_state_inc_tier).
 + *
-+ * The remaining drain entry, marie_drain_one_lruvec (in core.c), is
-+ * only the enable/disable transition: it walks the per-(type, gen,
-+ * tier) bitmap and hands every TRACKED folio back to the legacy LRU.
++ * No enable/disable drain entry remains either: Marie is selected
++ * once at boot via the lru_marie= static key, before any folio is
++ * tracked, so there is nothing to hand back to the legacy LRU.
 + */
 +
 +/*
@@ -9529,7 +9528,7 @@ index 0000000000..8edb82807a
 +#define MARIE_PROGNAME	"Marie LRU"
 +#define MARIE_AUTHOR	"Masahito Suzuki"
 +
-+#define MARIE_VERSION	"0.7.7"
++#define MARIE_VERSION	"0.7.8"
 +
 +#endif /* _MM_LRU_MARIE_VERSION_H */
 diff --git a/mm/lru_marie/walker.c b/mm/lru_marie/walker.c
@@ -10596,10 +10595,10 @@ index 0000000000..5942d25151
 +
 +#endif /* _MM_LRU_MARIE_WALKER_COMPAT_H */
 diff --git a/mm/memcontrol-v1.c b/mm/memcontrol-v1.c
-index 433bba9dfe..a7923ef2fa 100644
+index 7650692115..16636e0d43 100644
 --- a/mm/memcontrol-v1.c
 +++ b/mm/memcontrol-v1.c
-@@ -11,6 +11,7 @@
+@@ -10,6 +10,7 @@
  #include <linux/sort.h>
  #include <linux/file.h>
  #include <linux/seq_buf.h>
@@ -10607,7 +10606,7 @@ index 433bba9dfe..a7923ef2fa 100644
  
  #include "internal.h"
  #include "swap.h"
-@@ -2000,6 +2001,16 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
+@@ -2020,6 +2021,16 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
  	} else
  		WRITE_ONCE(vm_swappiness, val);
  
@@ -10625,7 +10624,7 @@ index 433bba9dfe..a7923ef2fa 100644
  }
  
 diff --git a/mm/memcontrol.c b/mm/memcontrol.c
-index 749c128b4f..12756d8863 100644
+index 6dc4888a90..b00c2ee52d 100644
 --- a/mm/memcontrol.c
 +++ b/mm/memcontrol.c
 @@ -28,6 +28,7 @@
@@ -10636,7 +10635,7 @@ index 749c128b4f..12756d8863 100644
  #include <linux/cgroup.h>
  #include <linux/cpuset.h>
  #include <linux/sched/mm.h>
-@@ -5178,6 +5179,26 @@ static void uncharge_folio(struct folio *folio, struct uncharge_gather *ug)
+@@ -5287,6 +5288,26 @@ static void uncharge_folio(struct folio *folio, struct uncharge_gather *ug)
  			ug->nr_memory += nr_pages;
  		ug->pgpgout++;
  
@@ -10664,7 +10663,7 @@ index 749c128b4f..12756d8863 100644
  	}
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index f9f8e1af92..aae01205e5 100644
+index 0f64909e8d..b8c8f26987 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -1395,6 +1395,9 @@ static void __meminit pgdat_init_internals(struct pglist_data *pgdat)
@@ -11012,7 +11011,7 @@ index 5f372f6e26..7020c0861f 100644
 +}
 +late_initcall(thrash_wd_init);
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 23c7298d3b..31d110475b 100644
+index ee902a468c..04c93a3b9a 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -16,6 +16,7 @@
@@ -11023,7 +11022,7 @@ index 23c7298d3b..31d110475b 100644
  #include <linux/highmem.h>
  #include <linux/interrupt.h>
  #include <linux/jiffies.h>
-@@ -1314,6 +1315,28 @@ __always_inline bool __free_pages_prepare(struct page *page,
+@@ -1326,6 +1327,28 @@ static __always_inline bool __free_pages_prepare(struct page *page,
  	trace_mm_page_free(page, order);
  	kmsan_free_page(page, order);
  
@@ -11031,7 +11030,7 @@ index 23c7298d3b..31d110475b 100644
 +	/*
 +	 * Wipe Marie's per-PFN state at the buddy handoff. Marie's reclaim
 +	 * isolate path intentionally leaves marie_state[pfn]'s TRACKED bit
-+	 * set across shrink_folio_list (so install_local's TRACKED early-
++	 * set across shrink_folio_list (so marie_folio_install's TRACKED early-
 +	 * out keeps blocking concurrent installs on the in-flight folio);
 +	 * this hook is the canonical point at which that stale bit must
 +	 * disappear so the next allocation at this PFN starts clean. No-op
@@ -11052,7 +11051,7 @@ index 23c7298d3b..31d110475b 100644
  	if (memcg_kmem_online() && PageMemcgKmem(page))
  		__memcg_kmem_uncharge_page(page, order);
  
-@@ -4576,25 +4599,97 @@ bool gfp_pfmemalloc_allowed(gfp_t gfp_mask)
+@@ -4580,25 +4603,97 @@ bool gfp_pfmemalloc_allowed(gfp_t gfp_mask)
  static inline bool
  should_reclaim_retry(gfp_t gfp_mask, unsigned order,
  		     struct alloc_context *ac, int alloc_flags,
@@ -11153,7 +11152,7 @@ index 23c7298d3b..31d110475b 100644
  
  	/*
  	 * Keep reclaiming pages while there is a chance this will lead
-@@ -4718,6 +4813,20 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4757,6 +4852,20 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  		WARN_ON_ONCE(current->flags & PF_MEMALLOC);
  	}
  
@@ -11174,7 +11173,7 @@ index 23c7298d3b..31d110475b 100644
  restart:
  	compaction_retries = 0;
  	no_progress_loops = 0;
-@@ -4725,6 +4834,9 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4764,6 +4873,9 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  	compact_priority = DEF_COMPACT_PRIORITY;
  	cpuset_mems_cookie = read_mems_allowed_begin();
  	zonelist_iter_cookie = zonelist_iter_begin();
@@ -11184,7 +11183,7 @@ index 23c7298d3b..31d110475b 100644
  
  	/*
  	 * For costly allocations, try direct compaction first, as it's likely
-@@ -4881,7 +4993,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+@@ -4934,7 +5046,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
  		goto restart;
  
  	if (should_reclaim_retry(gfp_mask, order, ac, alloc_flags,
@@ -11194,16 +11193,17 @@ index 23c7298d3b..31d110475b 100644
  
  	/*
 diff --git a/mm/page_io.c b/mm/page_io.c
-index 70cea9e24d..34930ac397 100644
+index b23f494fcc..63ff90fa90 100644
 --- a/mm/page_io.c
 +++ b/mm/page_io.c
-@@ -25,8 +25,19 @@
+@@ -25,9 +25,20 @@
  #include <linux/sched/task.h>
  #include <linux/delayacct.h>
  #include <linux/zswap.h>
 +#include <linux/kfifo.h>
 +#include <linux/lru_marie.h>
  #include "swap.h"
+ #include "swap_table.h"
  
 +#ifdef CONFIG_LRU_MARIE
 +/*
@@ -11217,7 +11217,7 @@ index 70cea9e24d..34930ac397 100644
  static void __end_swap_bio_write(struct bio *bio)
  {
  	struct folio *folio = bio_first_folio_all(bio);
-@@ -39,7 +50,21 @@ static void __end_swap_bio_write(struct bio *bio)
+@@ -40,7 +51,21 @@ static void __end_swap_bio_write(struct bio *bio)
  		 * very quickly.
  		 *
  		 * Also clear PG_reclaim to avoid folio_rotate_reclaimable()
@@ -11239,8 +11239,8 @@ index 70cea9e24d..34930ac397 100644
  		folio_mark_dirty(folio);
  		pr_alert_ratelimited("Write-error on swap-device (%u:%u:%llu)\n",
  				     MAJOR(bio_dev(bio)), MINOR(bio_dev(bio)),
-@@ -233,6 +258,120 @@ static void swap_zeromap_folio_clear(struct folio *folio)
- 	}
+@@ -244,6 +269,120 @@ static void swap_zeromap_folio_clear(struct folio *folio)
+ 	swap_cluster_unlock(ci);
  }
  
 +/*
@@ -11360,7 +11360,7 @@ index 70cea9e24d..34930ac397 100644
  /*
   * We may have stale swap cache pages in memory: notice
   * them here and get rid of the unnecessary final write.
-@@ -272,6 +411,14 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
+@@ -282,6 +421,14 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
  	 */
  	swap_zeromap_folio_clear(folio);
  
@@ -11375,7 +11375,7 @@ index 70cea9e24d..34930ac397 100644
  	if (zswap_store(folio)) {
  		count_mthp_stat(folio_order(folio), MTHP_STAT_ZSWPOUT);
  		goto out_unlock;
-@@ -292,6 +439,46 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
+@@ -302,6 +449,46 @@ int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug)
  	return ret;
  }
  
@@ -11423,7 +11423,7 @@ index 70cea9e24d..34930ac397 100644
  {
  #ifdef CONFIG_TRANSPARENT_HUGEPAGE
 diff --git a/mm/rmap.c b/mm/rmap.c
-index 78b7fb5f36..0cfaf5bcce 100644
+index 1c77d5dc06..898b893c09 100644
 --- a/mm/rmap.c
 +++ b/mm/rmap.c
 @@ -75,6 +75,7 @@
@@ -11447,7 +11447,7 @@ index 78b7fb5f36..0cfaf5bcce 100644
  			if (clear_flush_young_ptes_notify(vma, address, pvmw.pte, nr))
  				referenced++;
 diff --git a/mm/swap.c b/mm/swap.c
-index 5cc44f0de9..5696ddebbd 100644
+index 588f50d8f1..ec05a13949 100644
 --- a/mm/swap.c
 +++ b/mm/swap.c
 @@ -37,6 +37,7 @@
@@ -11502,7 +11502,7 @@ index 5cc44f0de9..5696ddebbd 100644
  }
  
  /*
-@@ -171,6 +200,27 @@ static void folio_batch_move_lru(struct folio_batch *fbatch, move_fn_t move_fn)
+@@ -199,6 +228,27 @@ static void folio_batch_move_lru(struct folio_batch *fbatch, move_fn_t move_fn)
  		folio_lruvec_relock_irqsave(folio, &lruvec, &flags);
  		move_fn(lruvec, folio);
  
@@ -11530,7 +11530,7 @@ index 5cc44f0de9..5696ddebbd 100644
  		folio_set_lru(folio);
  	}
  
-@@ -215,6 +265,44 @@ static void lru_move_tail(struct lruvec *lruvec, struct folio *folio)
+@@ -250,6 +300,44 @@ static void lru_move_tail(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_unevictable(folio))
  		return;
  
@@ -11575,7 +11575,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	lruvec_add_folio_tail(lruvec, folio);
-@@ -234,6 +322,14 @@ void folio_rotate_reclaimable(struct folio *folio)
+@@ -269,6 +357,14 @@ void folio_rotate_reclaimable(struct folio *folio)
  	    folio_test_unevictable(folio) || !folio_test_lru(folio))
  		return;
  
@@ -11590,7 +11590,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	folio_batch_add_and_move(folio, lru_move_tail);
  }
  
-@@ -304,6 +400,12 @@ void lru_note_cost_refault(struct folio *folio)
+@@ -339,6 +435,12 @@ void lru_note_cost_refault(struct folio *folio)
  				folio_nr_pages(folio), 0);
  }
  
@@ -11603,7 +11603,7 @@ index 5cc44f0de9..5696ddebbd 100644
  static void lru_activate(struct lruvec *lruvec, struct folio *folio)
  {
  	long nr_pages = folio_nr_pages(folio);
-@@ -311,10 +413,24 @@ static void lru_activate(struct lruvec *lruvec, struct folio *folio)
+@@ -346,10 +448,24 @@ static void lru_activate(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_active(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11629,7 +11629,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	trace_mm_lru_activate(folio);
  
  	__count_vm_events(PGACTIVATE, nr_pages);
-@@ -336,6 +452,13 @@ void folio_activate(struct folio *folio)
+@@ -371,6 +487,13 @@ void folio_activate(struct folio *folio)
  	    !folio_test_lru(folio))
  		return;
  
@@ -11643,7 +11643,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	folio_batch_add_and_move(folio, lru_activate);
  }
  
-@@ -351,6 +474,15 @@ void folio_activate(struct folio *folio)
+@@ -386,6 +509,15 @@ void folio_activate(struct folio *folio)
  	if (!folio_test_clear_lru(folio))
  		return;
  
@@ -11659,7 +11659,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	lruvec = folio_lruvec_lock_irq(folio);
  	lru_activate(lruvec, folio);
  	lruvec_unlock_irq(lruvec);
-@@ -466,6 +598,32 @@ void folio_mark_accessed(struct folio *folio)
+@@ -501,6 +633,32 @@ void folio_mark_accessed(struct folio *folio)
  		lru_gen_inc_refs(folio);
  		return;
  	}
@@ -11692,10 +11692,11 @@ index 5cc44f0de9..5696ddebbd 100644
  
  	if (!folio_test_referenced(folio)) {
  		folio_set_referenced(folio);
-@@ -510,9 +668,24 @@ void folio_add_lru(struct folio *folio)
+@@ -544,6 +702,30 @@ void folio_add_lru(struct folio *folio)
+ 			folio_test_unevictable(folio), folio);
  	VM_BUG_ON_FOLIO(folio_test_lru(folio), folio);
  
- 	/* see the comment in lru_gen_folio_seq() */
++	/* see the comment in lru_gen_folio_seq() */
 +#ifdef CONFIG_LRU_MARIE
 +	/*
 +	 * Marie bypass: Marie tracks folios via per-PFN state bytes,
@@ -11705,19 +11706,32 @@ index 5cc44f0de9..5696ddebbd 100644
 +	 * VM_BUG_ON_FOLIO(folio_test_active(folio), folio) in
 +	 * mm/vmscan.c. Skip the MGLRU fault hint when Marie owns
 +	 * the LRU. (See also defensive clear in lru_marie_add_folio.)
++	 *
++	 * Otherwise apply the 7.2 fault hint: refaulted workingset
++	 * folios get PG_active; not-yet-referenced (prefaulted file)
++	 * folios get folio_mark_accessed() -> PG_referenced so
++	 * lru_gen_folio_seq() places them into the second oldest gen.
 +	 */
 +	if (!lru_marie_enabled() && lru_gen_enabled() && !folio_test_unevictable(folio) &&
-+	    lru_gen_in_fault() && !(current->flags & PF_MEMALLOC))
-+		folio_set_active(folio);
++	    lru_gen_in_fault() && !(current->flags & PF_MEMALLOC)) {
++		if (folio_test_workingset(folio))
++			folio_set_active(folio);
++		else if (!folio_test_referenced(folio))
++			folio_mark_accessed(folio);
++	}
 +#else
- 	if (lru_gen_enabled() && !folio_test_unevictable(folio) &&
- 	    lru_gen_in_fault() && !(current->flags & PF_MEMALLOC))
- 		folio_set_active(folio);
+ 	/*
+ 	 * For refaulted workingset folios, set PG_active so they
+ 	 * can be added to active generations.
+@@ -558,6 +740,7 @@ void folio_add_lru(struct folio *folio)
+ 		else if (!folio_test_referenced(folio))
+ 			folio_mark_accessed(folio);
+ 	}
 +#endif
  
  	folio_batch_add_and_move(folio, lru_add);
  }
-@@ -569,6 +742,11 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
+@@ -614,6 +797,11 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
  	if (folio_mapped(folio))
  		return;
  
@@ -11729,7 +11743,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	folio_clear_referenced(folio);
-@@ -580,14 +758,24 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
+@@ -625,14 +813,24 @@ static void lru_deactivate_file(struct lruvec *lruvec, struct folio *folio)
  		 * race window is _really_ small and  it's not a critical
  		 * problem.
  		 */
@@ -11756,7 +11770,7 @@ index 5cc44f0de9..5696ddebbd 100644
  		__count_vm_events(PGROTATED, nr_pages);
  	}
  
-@@ -605,10 +793,20 @@ static void lru_deactivate(struct lruvec *lruvec, struct folio *folio)
+@@ -650,10 +848,20 @@ static void lru_deactivate(struct lruvec *lruvec, struct folio *folio)
  	if (folio_test_unevictable(folio) || !(folio_test_active(folio) || lru_gen_enabled()))
  		return;
  
@@ -11778,7 +11792,7 @@ index 5cc44f0de9..5696ddebbd 100644
  
  	__count_vm_events(PGDEACTIVATE, nr_pages);
  	count_memcg_events(lruvec_memcg(lruvec), PGDEACTIVATE, nr_pages);
-@@ -622,6 +820,11 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
+@@ -667,6 +875,11 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
  	    folio_test_swapcache(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11790,7 +11804,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	lruvec_del_folio(lruvec, folio);
  	folio_clear_active(folio);
  	if (lru_gen_enabled())
-@@ -634,7 +837,12 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
+@@ -679,7 +892,12 @@ static void lru_lazyfree(struct lruvec *lruvec, struct folio *folio)
  	 * anonymous folios
  	 */
  	folio_clear_swapbacked(folio);
@@ -11804,7 +11818,7 @@ index 5cc44f0de9..5696ddebbd 100644
  
  	__count_vm_events(PGLAZYFREE, nr_pages);
  	count_memcg_events(lruvec_memcg(lruvec), PGLAZYFREE, nr_pages);
-@@ -698,6 +906,13 @@ void deactivate_file_folio(struct folio *folio)
+@@ -743,6 +961,13 @@ void deactivate_file_folio(struct folio *folio)
  	if (lru_gen_enabled() && lru_gen_clear_refs(folio))
  		return;
  
@@ -11818,7 +11832,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	folio_batch_add_and_move(folio, lru_deactivate_file);
  }
  
-@@ -717,6 +932,13 @@ void folio_deactivate(struct folio *folio)
+@@ -762,6 +987,13 @@ void folio_deactivate(struct folio *folio)
  	if (lru_gen_enabled() ? lru_gen_clear_refs(folio) : !folio_test_active(folio))
  		return;
  
@@ -11832,7 +11846,7 @@ index 5cc44f0de9..5696ddebbd 100644
  	folio_batch_add_and_move(folio, lru_deactivate);
  }
  
-@@ -734,6 +956,14 @@ void folio_mark_lazyfree(struct folio *folio)
+@@ -779,6 +1011,14 @@ void folio_mark_lazyfree(struct folio *folio)
  	    folio_test_swapcache(folio) || folio_test_unevictable(folio))
  		return;
  
@@ -11848,10 +11862,10 @@ index 5cc44f0de9..5696ddebbd 100644
  }
  
 diff --git a/mm/swap.h b/mm/swap.h
-index a77016f242..fc816e14de 100644
+index 77d2d14eda..4b915f45e1 100644
 --- a/mm/swap.h
 +++ b/mm/swap.h
-@@ -227,6 +227,10 @@ static inline void swap_read_unplug(struct swap_iocb *plug)
+@@ -251,6 +251,10 @@ static inline void swap_read_unplug(struct swap_iocb *plug)
  void swap_write_unplug(struct swap_iocb *sio);
  int swap_writeout(struct folio *folio, struct swap_iocb **swap_plug);
  void __swap_writepage(struct folio *folio, struct swap_iocb **swap_plug);
@@ -11863,7 +11877,7 @@ index a77016f242..fc816e14de 100644
  /* linux/mm/swap_state.c */
  extern struct address_space swap_space __read_mostly;
 diff --git a/mm/vmscan.c b/mm/vmscan.c
-index bd1b1aa125..975007fa9f 100644
+index 35c3bb15ae..6a4412e5d2 100644
 --- a/mm/vmscan.c
 +++ b/mm/vmscan.c
 @@ -39,6 +39,7 @@
@@ -11874,7 +11888,7 @@ index bd1b1aa125..975007fa9f 100644
  #include <linux/migrate.h>
  #include <linux/delayacct.h>
  #include <linux/sysctl.h>
-@@ -181,6 +182,34 @@ struct scan_control {
+@@ -179,6 +180,34 @@ struct scan_control {
  	struct reclaim_state reclaim_state;
  };
  
@@ -11909,7 +11923,7 @@ index bd1b1aa125..975007fa9f 100644
  #ifdef ARCH_HAS_PREFETCHW
  #define prefetchw_prev_lru_folio(_folio, _base, _field)			\
  	do {								\
-@@ -458,6 +487,44 @@ static int reclaimer_offset(struct scan_control *sc)
+@@ -456,6 +485,44 @@ static int reclaimer_offset(struct scan_control *sc)
  	return PGSTEAL_DIRECT - PGSTEAL_KSWAPD;
  }
  
@@ -11954,7 +11968,7 @@ index bd1b1aa125..975007fa9f 100644
  /*
   * We detected a synchronous write error writing a folio out.  Probably
   * -ENOSPC.  We need to propagate that into the address_space for a subsequent
-@@ -877,10 +944,7 @@ static enum folio_references folio_check_references(struct folio *folio,
+@@ -874,10 +941,7 @@ static enum folio_references folio_check_references(struct folio *folio,
  		return FOLIOREF_ACTIVATE;
  
  	/*
@@ -11966,7 +11980,7 @@ index bd1b1aa125..975007fa9f 100644
  	 */
  	if (referenced_ptes == -1)
  		return FOLIOREF_KEEP;
-@@ -894,6 +958,30 @@ static enum folio_references folio_check_references(struct folio *folio,
+@@ -891,6 +955,30 @@ static enum folio_references folio_check_references(struct folio *folio,
  
  	referenced_folio = folio_test_clear_referenced(folio);
  
@@ -11997,7 +12011,7 @@ index bd1b1aa125..975007fa9f 100644
  	if (referenced_ptes) {
  		/*
  		 * All mapped folios start out with page table
-@@ -1053,9 +1141,13 @@ static bool may_enter_fs(struct folio *folio, gfp_t gfp_mask)
+@@ -1050,9 +1138,13 @@ static bool may_enter_fs(struct folio *folio, gfp_t gfp_mask)
  }
  
  /*
@@ -12013,7 +12027,7 @@ index bd1b1aa125..975007fa9f 100644
  		struct pglist_data *pgdat, struct scan_control *sc,
  		struct reclaim_stat *stat, bool ignore_references,
  		struct mem_cgroup *memcg)
-@@ -1916,7 +2008,29 @@ static unsigned int move_folios_to_lru(struct list_head *list)
+@@ -1913,7 +2005,29 @@ static unsigned int move_folios_to_lru(struct list_head *list)
  			continue;
  		}
  
@@ -12044,7 +12058,7 @@ index bd1b1aa125..975007fa9f 100644
  		nr_pages = folio_nr_pages(folio);
  		nr_moved += nr_pages;
  		if (folio_test_active(folio))
-@@ -5307,6 +5421,55 @@ static bool drain_evictable(struct lruvec *lruvec)
+@@ -5262,6 +5376,55 @@ static bool drain_evictable(struct lruvec *lruvec)
  	return true;
  }
  
@@ -12100,7 +12114,7 @@ index bd1b1aa125..975007fa9f 100644
  static void lru_gen_change_state(bool enabled)
  {
  	static DEFINE_MUTEX(state_mutex);
-@@ -5827,7 +5990,15 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
+@@ -5783,7 +5946,15 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
  	struct lru_gen_mm_state *mm_state = get_mm_state(lruvec);
  
  	lrugen->max_seq = MIN_NR_GENS + 1;
@@ -12117,7 +12131,7 @@ index bd1b1aa125..975007fa9f 100644
  
  	for (i = 0; i <= MIN_NR_GENS + 1; i++)
  		lrugen->timestamps[i] = jiffies;
-@@ -5927,7 +6098,23 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
+@@ -5883,7 +6054,23 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
  	unsigned long nr_to_reclaim = sc->nr_to_reclaim;
  	bool proportional_reclaim;
  	struct blk_plug plug;
@@ -12141,7 +12155,7 @@ index bd1b1aa125..975007fa9f 100644
  	if ((lru_gen_enabled() || lru_gen_switching()) && !root_reclaim(sc)) {
  		lru_gen_shrink_lruvec(lruvec, sc);
  
-@@ -5938,6 +6125,29 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
+@@ -5894,6 +6081,29 @@ static void shrink_lruvec(struct lruvec *lruvec, struct scan_control *sc)
  
  	get_scan_count(lruvec, sc, nr);
  
@@ -12171,7 +12185,7 @@ index bd1b1aa125..975007fa9f 100644
  	/* Record the original scan target for proportional adjustments later */
  	memcpy(targets, nr, sizeof(nr));
  
-@@ -6193,14 +6403,32 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
+@@ -6149,14 +6359,32 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
  	struct lruvec *target_lruvec;
  	bool reclaimable = false;
  
@@ -12205,7 +12219,7 @@ index bd1b1aa125..975007fa9f 100644
  
  	target_lruvec = mem_cgroup_lruvec(sc->target_mem_cgroup, pgdat);
  
-@@ -6469,6 +6697,17 @@ static void snapshot_refaults(struct mem_cgroup *target_memcg, pg_data_t *pgdat)
+@@ -6425,6 +6653,17 @@ static void snapshot_refaults(struct mem_cgroup *target_memcg, pg_data_t *pgdat)
  	struct lruvec *target_lruvec;
  	unsigned long refaults;
  
@@ -12223,7 +12237,7 @@ index bd1b1aa125..975007fa9f 100644
  	if (lru_gen_enabled() && !lru_gen_switching())
  		return;
  
-@@ -6859,6 +7098,21 @@ static void kswapd_age_node(struct pglist_data *pgdat, struct scan_control *sc)
+@@ -6815,6 +7054,21 @@ static void kswapd_age_node(struct pglist_data *pgdat, struct scan_control *sc)
  	struct mem_cgroup *memcg;
  	struct lruvec *lruvec;
  
@@ -12245,7 +12259,7 @@ index bd1b1aa125..975007fa9f 100644
  	if (lru_gen_enabled() || lru_gen_switching()) {
  		lru_gen_age_node(pgdat, sc);
  
-@@ -7632,6 +7886,9 @@ unsigned long shrink_all_memory(unsigned long nr_to_reclaim)
+@@ -7593,6 +7847,9 @@ unsigned long shrink_all_memory(unsigned long nr_to_reclaim)
  void __meminit kswapd_run(int nid)
  {
  	pg_data_t *pgdat = NODE_DATA(nid);
@@ -12255,7 +12269,7 @@ index bd1b1aa125..975007fa9f 100644
  
  	pgdat_kswapd_lock(pgdat);
  	if (!pgdat->kswapd) {
-@@ -7645,7 +7902,32 @@ void __meminit kswapd_run(int nid)
+@@ -7606,7 +7863,32 @@ void __meminit kswapd_run(int nid)
  		} else {
  			wake_up_process(pgdat->kswapd);
  		}
@@ -12288,7 +12302,7 @@ index bd1b1aa125..975007fa9f 100644
  	pgdat_kswapd_unlock(pgdat);
  }
  
-@@ -7664,16 +7946,52 @@ void __meminit kswapd_stop(int nid)
+@@ -7625,16 +7907,52 @@ void __meminit kswapd_stop(int nid)
  		kthread_stop(kswapd);
  		pgdat->kswapd = NULL;
  	}


### PR DESCRIPTION
## Summary

Bumps all testing patches to **Marie LRU v0.7.8**. This release contains **one
functional fix** and a **documentation hygiene sweep**. No behavioral changes
beyond the single bug fix; no ABI / tunable / sysfs changes.

Affected patches (all in `patches/testing/`):
`0001-linux6.16.12`, `0001-linux6.18.22`,
`0001-linux7.0`, `0001-linux7.1-rc5`, `0001-linux7.2-rc1`.

## Functional fix

### Fix `swap_bias` lost-update race (`mm/lru_marie/state.c`)

`marie_swap_bias_update()` updated the global anon:file proportional bias with
`atomic64_read()` + `atomic64_set()`. Under concurrent direct reclaim, two
reclaimers can interleave read→set and silently lose each other's update,
skewing the long-run `s:(MAX_SWAPPINESS−s)` page-flow ratio that the
proportional controller (swappiness 2..199) converges to.

```c
/* before */
cur = atomic64_read(&marie_swap_bias);
atomic64_set(&marie_swap_bias, cur + delta);

/* after */
atomic64_add(delta, &marie_swap_bias);
```

Impact scope: proportional swappiness regime (2..199) only. The fix is
dormant under the default configuration, where `low_swappiness_mode` clamps
effective swappiness to 1 (FILE_THEN_ANON) and the bias controller is
bypassed by design.

## Documentation sweep (no functional change)

Corrects stale comments that drifted from the code:

- `MARIE_PFN_NR_GENS = 4` → `8` (core.c header); gen-ring masks `&3` → `&7`
- `clean_min_ratio` comment "Default 15" → `10` (matches the actual initializer)
- Drop references to removed symbols presented as current:
  `marie_drain_one_lruvec`, `design.h`, `marie_install_at_gen`,
  `install_local`/`install_locked` (explicit "former" history kept),
  `marie_find_oldest_occupied` → `marie_find_oldest_occupied_mlv`
- `marie_state_move_to_gen` caller lists now name the actual callers
  (`marie_folio_demote` / `lru_marie_lazyfree`, both `(pfn, oldest, 0)`)

Cc: Masahito Suzuki [firelzrd@gmail.com](mailto:firelzrd@gmail.com)